### PR TITLE
Update astro to 0.21 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,3 @@ When viewing the localhost site for the first time, you may see the following di
 
 Refresh your browser to work around this warning. The correctly rendered page will display after one or two refreshes.
 
-### Extended Unicode characters not rendering correctly
-
-Characters outside of the Basic Latin script do not render correctly. This should be resolved soon.
-
-e.g. _Latin Small Letter N with tilde_, ñ

--- a/README.md
+++ b/README.md
@@ -44,5 +44,4 @@ When viewing the localhost site for the first time, you may see the following di
 >
 > The current page should have reloaded by now
 
-Refresh your browser to work around this warning. The correctly rendered page will display after one or two refreshes.
-
+Refresh your browser to work around this warning. The correctly rendered page will display after one or two refreshes.  Upstream issue: https://github.com/withastro/astro/issues/1803

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,15 @@
       "devDependencies": {
         "@astrojs/renderer-react": "^0.3.0-next.1",
         "@snowpack/plugin-dotenv": "^2.1.0",
-        "astro": "^0.21.0-next.11",
+        "astro": "^0.21.4",
         "netlify-cms-proxy-server": "^1.3.22",
         "npm-run-all": "^4.1.5"
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.3.3.tgz",
-      "integrity": "sha512-iARMoTw6RgpLZyHoJPE34FSVphMZDGJ6U7FCqSErGfRzLhL6YY4o/UT4woqZ5yjcPLnoArNEx/KQfAYB07Stsw==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.3.9.tgz",
+      "integrity": "sha512-TzmIzpB6bpGD3vghcj+cXPckXkRCf6zHcVupf6F2b9WpFkMAvrXoafkKJIids2Mq9aU4p7ooVcIDGZ9tpqZpyw==",
       "dev": true,
       "dependencies": {
         "typescript": "^4.3.5"
@@ -60,46 +60,45 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "0.4.0-next.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-0.4.0-next.2.tgz",
-      "integrity": "sha512-mk/fOALeQR9xOwz2I03Sz391sx+vpt+ySW+oe8oQ5c3y8VYddeZEBNOrQv+lp5cgG+3c5AT5pP9LhbLB1r8Rmw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-0.5.0.tgz",
+      "integrity": "sha512-2A+PNNZ1w/GOZeLGRBco8QO6o3R8xtJY5EbQXwP3KmZ8xQZuVsZxX4HFpkFOvzm7ADCHZr7h6yVSdaoOAUb6UQ==",
       "dev": true,
       "dependencies": {
-        "@astrojs/prism": "^0.3.0-next.0",
-        "@silvenon/remark-smartypants": "^1.0.0",
+        "@astrojs/prism": "^0.3.0",
         "assert": "^2.0.0",
-        "github-slugger": "^1.3.0",
+        "github-slugger": "^1.4.0",
         "gray-matter": "^4.0.3",
         "mdast-util-mdx-expression": "^1.1.1",
-        "mdast-util-mdx-jsx": "^1.1.1",
-        "micromark-extension-mdx-expression": "^1.0.0",
-        "micromark-extension-mdx-jsx": "^1.0.0",
+        "mdast-util-mdx-jsx": "^1.1.3",
+        "micromark-extension-mdx-expression": "^1.0.3",
+        "micromark-extension-mdx-jsx": "^1.0.2",
         "prismjs": "^1.25.0",
-        "rehype-raw": "^6.0.0",
-        "rehype-stringify": "^9.0.1",
-        "remark-footnotes": "^4.0.1",
-        "remark-gfm": "^2.0.0",
-        "remark-parse": "^10.0.0",
-        "remark-rehype": "^9.0.0",
-        "remark-slug": "^7.0.0",
-        "unified": "^10.1.0",
+        "rehype-raw": "^6.1.0",
+        "rehype-slug": "^5.0.0",
+        "rehype-stringify": "^9.0.2",
+        "remark-gfm": "^3.0.1",
+        "remark-parse": "^10.0.1",
+        "remark-rehype": "^10.0.1",
+        "remark-smartypants": "^2.0.0",
+        "unified": "^10.1.1",
         "unist-util-map": "^3.0.0",
-        "unist-util-visit": "^4.0.0"
+        "unist-util-visit": "^4.1.0"
       }
     },
     "node_modules/@astrojs/prism": {
-      "version": "0.3.0-next.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-0.3.0-next.0.tgz",
-      "integrity": "sha512-GNw7H5wA8Y9MjKxcilB6hMf0hSN1pwoLQE7HCMDUt0xOHW2JWuRSoVeIsu5+XLD5XnAXUcQij7M+xMu36N/tPg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-0.3.0.tgz",
+      "integrity": "sha512-5U+jcgfibLKW8PwnHQEdmgb+uZVeMVLz+paEr3vxKgikYfjXDjQu6qEDLOW3WTc/cIWrOF9rAtTKy8R/ArPscw==",
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@astrojs/renderer-preact": {
-      "version": "0.3.0-next.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/renderer-preact/-/renderer-preact-0.3.0-next.1.tgz",
-      "integrity": "sha512-GWt3iphGKlstJQSPAwj5/3OPi1IOpEpnjeiW0qw+n2xy1aHTmdP9/BMvDvJFiQgIXl7hc+P82rU4yKz5znMPOQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/renderer-preact/-/renderer-preact-0.3.0.tgz",
+      "integrity": "sha512-gw+LpSdJXeSXdMTc9aIvVHiOyBs9w37D1yGogE/cleStIN9nTM6TVeU06gtZkIHOViOGAsMXTCrM7enr6VBMKQ==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.16.0",
@@ -111,9 +110,9 @@
       }
     },
     "node_modules/@astrojs/renderer-react": {
-      "version": "0.3.0-next.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/renderer-react/-/renderer-react-0.3.0-next.1.tgz",
-      "integrity": "sha512-m3samDo32cIFqANyHv2RBQzM4zwN4a8hdxaZ0H9kWeux0ggSKQVIiYMJvRe84IR9CbHs2hFHtaszK4FdxD2/mg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/renderer-react/-/renderer-react-0.3.0.tgz",
+      "integrity": "sha512-pb9gKVHJwtFNoYrtSnBfOPm/0IerEGe6MCDrgys5lwVPWiZ9Di+7uK+C2/UdBuHDM8NEKw+zXA+6qZi/endy+g==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.16.0",
@@ -125,22 +124,23 @@
       }
     },
     "node_modules/@astrojs/renderer-svelte": {
-      "version": "0.2.0-next.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/renderer-svelte/-/renderer-svelte-0.2.0-next.1.tgz",
-      "integrity": "sha512-BJ4OtP7pH8yk7XZIJ0f2QOZ7aP24NeAEuS7pfKyOyYZ0DL+qXUGzSlE/XYAwZtGW3ph6Nzsh6VK0woYOtBsrOw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/renderer-svelte/-/renderer-svelte-0.2.1.tgz",
+      "integrity": "sha512-0pifE/w+K6eLrDT0urBYPOBJzF7e4sL3+td7o1p4a3yGXPQsr5eKKQ66lyIKl7sgg5bXOVQhVMQbnm6rGqHxVA==",
       "dev": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
-        "svelte": "^3.44.1"
+        "svelte": "^3.44.2",
+        "svelte-preprocess": "^4.9.8"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@astrojs/renderer-vue": {
-      "version": "0.2.0-next.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/renderer-vue/-/renderer-vue-0.2.0-next.2.tgz",
-      "integrity": "sha512-Px3MRkjQF3qikBA6p0UdaOr42VUPRMIUWsBbdGQk+LeNVmUnmQuhBwBS5qy+i+DXaS+JnOIMK01SU0klTLTE2Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/renderer-vue/-/renderer-vue-0.2.0.tgz",
+      "integrity": "sha512-YfQwghT0/n/tNbi/93wWsqNUwUxRCi76CdNvBRNyP01JVTZisQyqtT8yOJYGgMgqxQEscpPmD467dK89knd5gQ==",
       "dev": true,
       "dependencies": {
         "@vitejs/plugin-vue": "^1.9.4",
@@ -923,56 +923,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/@silvenon/remark-smartypants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@silvenon/remark-smartypants/-/remark-smartypants-1.0.0.tgz",
-      "integrity": "sha512-+Icx9z8zKBdO9mMcsUkfRbzGkHDXmv+Q4TyoPTiuhTrWK2UtLUglfTB5iRacuYHzNYKC4hJIJmTlC5c7fNxOiw==",
-      "dev": true,
-      "dependencies": {
-        "retext": "^7.0.1",
-        "retext-smartypants": "^4.0.0",
-        "unist-util-visit": "^2.0.1"
-      }
-    },
-    "node_modules/@silvenon/remark-smartypants/node_modules/unist-util-is": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@silvenon/remark-smartypants/node_modules/unist-util-visit": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@silvenon/remark-smartypants/node_modules/unist-util-visit-parents": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/@snowpack/plugin-dotenv": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@snowpack/plugin-dotenv/-/plugin-dotenv-2.2.0.tgz",
@@ -1139,6 +1089,15 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
+    "node_modules/@types/nlcst": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-1.0.0.tgz",
+      "integrity": "sha512-3TGCfOcy8R8mMQ4CNSNOe3PG66HttvjcLzCoOpvXvDtfWOTi+uT/rxeOKm/qEwbM4SNe1O/PjdiBK2YcTjU4OQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "16.11.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
@@ -1159,6 +1118,12 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
+    "node_modules/@types/pug": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.5.tgz",
+      "integrity": "sha512-LOnASQoeNZMkzexRuyqcBBDZ6rS+rQxUMkmj5A0PkhhiSZivLIuz6Hxyr1mkGoEZEkk66faROmpMi4fFkrKsBA==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "17.0.34",
@@ -1191,6 +1156,15 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.1.tgz",
       "integrity": "sha512-Ku5+GPFa12S3W26Uwtw+xyrtIpaZsGYHH6zxNbZlstmlvMYSZRzOwzwsXbxlVUbHyUucctSyuFtu6bNxwYomIw==",
       "dev": true
+    },
+    "node_modules/@types/sass": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
+      "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
@@ -1227,9 +1201,9 @@
       "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.9.4.tgz",
-      "integrity": "sha512-0CZqaCoChriPTTtGkERy1LGPcYjGFpi2uYRhBPIkqJqUGV5JnJFhQAgh6oH9j5XZHfrRaisX8W0xSpO4T7S78A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.10.1.tgz",
+      "integrity": "sha512-oL76QETMSpVE9jIScirGB2bYJEVU/+r+g+K7oG+sXPs9TZljqveoVRsmLyXlMZTjpQkLL8gz527cW80NMGVKJg==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -1239,13 +1213,13 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-      "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.23.tgz",
+      "integrity": "sha512-4ZhiI/orx+7EJ1B+0zjgvXMV2uRN+XBfG06UN2sJfND9rH5gtEQT3QmO4erum1o6Irl7y754W8/KSaDJh4EUQg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.22",
+        "@vue/shared": "3.2.23",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       }
@@ -1260,27 +1234,27 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz",
-      "integrity": "sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.23.tgz",
+      "integrity": "sha512-X2Nw8QFc5lgoK3kio5ktM95nqmLUH+q+N/PbV4kCHzF1avqv/EGLnAhaaF0Iu4bewNvHJAAhhwPZFeoV/22nbw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/compiler-core": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.22.tgz",
-      "integrity": "sha512-tWRQ5ge1tsTDhUwHgueicKJ8rYm6WUVAPTaIpFW3GSwZKcOEJ2rXdfkHFShNVGupeRALz2ET2H84OL0GeRxY0A==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.23.tgz",
+      "integrity": "sha512-Aw+pb50Q5zTjyvWod8mNKmYZDRGHJBptmNNWE+84ZxrzEztPgMz8cNYIzWGbwcFVkmJlhvioAMvKnB+LM/sjSA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.22",
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/compiler-ssr": "3.2.22",
-        "@vue/ref-transform": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@vue/compiler-core": "3.2.23",
+        "@vue/compiler-dom": "3.2.23",
+        "@vue/compiler-ssr": "3.2.23",
+        "@vue/ref-transform": "3.2.23",
+        "@vue/shared": "3.2.23",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
@@ -1297,75 +1271,75 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.22.tgz",
-      "integrity": "sha512-Cl6aoLJtXzzBkk1sKod8S0WBJLts3+ugVC91d22gGpbkw/64WnF12tOZi7Rg54PPLi1NovqyNWPsLH/SAFcu+w==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.23.tgz",
+      "integrity": "sha512-Bqzn4jFyXPK1Ehqiq7e/czS8n62gtYF1Zfeu0DrR5uv+SBllh7LIvZjZU6+c8qbocAd3/T3I3gn2cZGmnDb6zg==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/compiler-dom": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.22.tgz",
-      "integrity": "sha512-xNkLAItjI0xB+lFeDgKCrSItmrHTaAzSnt8LmdSCPQnDyarmzbi/u4ESQnckWvlL7lSRKiEaOvblaNyqAa7OnQ==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.23.tgz",
+      "integrity": "sha512-8RGVr/5Kpgb/EkCjgHXqttgA5IMc6n0lIXFY4TVbMkzdXrvaIhzBd7Te44oIDsTSYVKZLpfHd6/wEnuDqE8vFw==",
       "dev": true,
       "dependencies": {
-        "@vue/shared": "3.2.22"
+        "@vue/shared": "3.2.23"
       }
     },
     "node_modules/@vue/ref-transform": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.22.tgz",
-      "integrity": "sha512-qalVWbq5xWWxLZ0L9OroBg/JZhzavQuCcDXblfErxyDEH6Xc5gIJ4feo1SVCICFzhAUgLgQTdSFLpgjBawbFpw==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.23.tgz",
+      "integrity": "sha512-gW0GD2PSAs/th7mC7tPB/UwpIQxclbApVtsDtscDmOJXb2+cdu60ny+SuHNgfrlUT/JqWKQHq7jFKO4woxLNaA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@vue/compiler-core": "3.2.23",
+        "@vue/shared": "3.2.23",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.22.tgz",
-      "integrity": "sha512-e7WOC55wmHPvmoVUk9VBe/Z9k5bJfWJfVIlkUkiADJn0bOgQD29oh/GS14Kb3aEJXIHLI17Em6+HxNut1sIh7Q==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.23.tgz",
+      "integrity": "sha512-wSI5lmY2kCGLf89iiygqxVh6/5bsawz78Me9n1x4U2bHnN0yf3PWyuhN0WgIE8VfEaF7e75E333uboNEIFjgkg==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/reactivity": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.22.tgz",
-      "integrity": "sha512-w7VHYJoliLRTLc5beN77wxuOjla4v9wr2FF22xpZFYBmH4U1V7HkYhoHc1BTuNghI15CXT1tNIMhibI1nrQgdw==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.23.tgz",
+      "integrity": "sha512-z6lp0888NkLmxD9j2sGoll8Kb7J743s8s6w7GbiyUc4WZwm0KJ35B4qTFDMoIU0G7CatS6Z+yRTpPHc6srtByg==",
       "dev": true,
       "dependencies": {
-        "@vue/runtime-core": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@vue/runtime-core": "3.2.23",
+        "@vue/shared": "3.2.23",
         "csstype": "^2.6.8"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.22.tgz",
-      "integrity": "sha512-jCwbQgKPXiXoH9VS9F7K+gyEvEMrjutannwEZD1R8fQ9szmOTqC+RRbIY3Uf2ibQjZtZ8DV9a4FjxICvd9zZlQ==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.23.tgz",
+      "integrity": "sha512-mgQ2VAE5WjeZELJKNbwE69uiBNpN+3LyL0ZDki1bJWVwHD2fhPfx7pwyYuiucE81xz2LxVsyGxhKKUL997g8vw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/compiler-ssr": "3.2.23",
+        "@vue/shared": "3.2.23"
       },
       "peerDependencies": {
-        "vue": "3.2.22"
+        "vue": "3.2.23"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
-      "integrity": "sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.23.tgz",
+      "integrity": "sha512-U+/Jefa0QfXUF2qVy9Dqlrb6HKJSr9/wJcM66wXmWcTOoqg7hOWzF4qruDle51pyF4x3wMn6TSH54UdjKjCKMA==",
       "dev": true
     },
     "node_modules/@web/parse5-utils": {
@@ -1681,19 +1655,19 @@
       }
     },
     "node_modules/astro": {
-      "version": "0.21.0-next.11",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-0.21.0-next.11.tgz",
-      "integrity": "sha512-+h7ylkmfN9r3A8V8WfHLyk9kS//vq0zCBnlEG16WljN5BNFKZkImxuCsLOGwQzvuGeyUkS52jLKJqN7lRTE8HA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-0.21.4.tgz",
+      "integrity": "sha512-LDGPBbRDb54NZxRKzYEypphyoyVY5WwL3Lg/i9DiUlYmojfm5q/tw8kRgVj+nP0VNrJ/SrzIeVgtJmXMhwa3UQ==",
       "dev": true,
       "dependencies": {
-        "@astrojs/compiler": "^0.3.3",
+        "@astrojs/compiler": "^0.3.9",
         "@astrojs/language-server": "^0.7.16",
-        "@astrojs/markdown-remark": "^0.4.0-next.2",
-        "@astrojs/prism": "0.3.0-next.0",
-        "@astrojs/renderer-preact": "^0.3.0-next.1",
-        "@astrojs/renderer-react": "0.3.0-next.1",
-        "@astrojs/renderer-svelte": "0.2.0-next.1",
-        "@astrojs/renderer-vue": "0.2.0-next.2",
+        "@astrojs/markdown-remark": "^0.5.0",
+        "@astrojs/prism": "0.3.0",
+        "@astrojs/renderer-preact": "^0.3.0",
+        "@astrojs/renderer-react": "0.3.0",
+        "@astrojs/renderer-svelte": "0.2.1",
+        "@astrojs/renderer-vue": "0.2.0",
         "@babel/core": "^7.15.8",
         "@babel/traverse": "^7.15.4",
         "@proload/core": "^0.2.1",
@@ -1707,10 +1681,12 @@
         "es-module-lexer": "^0.7.1",
         "esbuild": "0.13.7",
         "estree-util-value-to-estree": "^1.2.0",
+        "fast-glob": "^3.2.7",
         "fast-xml-parser": "^3.19.0",
         "html-entities": "^2.3.2",
         "htmlparser2": "^7.1.2",
         "kleur": "^4.1.4",
+        "magic-string": "^0.25.7",
         "mime": "^2.5.2",
         "morphdom": "^2.6.1",
         "node-fetch": "^3.0.0",
@@ -1718,10 +1694,10 @@
         "path-to-regexp": "^6.2.0",
         "postcss": "^8.3.8",
         "prismjs": "^1.25.0",
-        "remark-slug": "^7.0.0",
+        "rehype-slug": "^5.0.0",
         "resolve": "^1.20.0",
         "rollup": "^2.57.0",
-        "sass": "^1.43.3",
+        "sass": "^1.43.4",
         "semver": "^7.3.5",
         "send": "^0.17.1",
         "shiki": "^0.9.10",
@@ -1733,6 +1709,7 @@
         "strip-ansi": "^7.0.1",
         "supports-esm": "^1.0.0",
         "tsconfig-resolver": "^3.0.1",
+        "vite": "^2.6.10",
         "yargs-parser": "^20.2.9",
         "zod": "^3.8.1"
       },
@@ -2268,6 +2245,15 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -2645,6 +2631,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.0.tgz",
+      "integrity": "sha512-KTiXDlRp9MMm/nlgI8rDGKoNNKiTJBl0RPjnBM680m2HlgJEA4JTASspK44lsvE4GQJildMRFp2HdEBiG+nqng==",
+      "dev": true,
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -2698,6 +2697,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diacritics": {
@@ -2976,6 +2984,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
       "dev": true
     },
     "node_modules/esbuild": {
@@ -3595,6 +3609,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3677,6 +3697,26 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
       "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==",
       "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -3891,6 +3931,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-2.1.0.tgz",
+      "integrity": "sha512-w+Rw20Q/iWp2Bcnr6uTrYU6/ftZLbHKhvc8nM26VIWpDqDMlku2iXUVTeOlsdoih/UKQhY7PHQ+vZ0Aqq8bxtQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.1.tgz",
@@ -4052,6 +4105,19 @@
         "property-information": "^6.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4242,6 +4308,16 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -5087,29 +5163,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mdast-util-footnote": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-footnote/-/mdast-util-footnote-1.0.0.tgz",
-      "integrity": "sha512-DBQervPt/8PZOebnKZu2dXsLXgKHfCirW5BIR824z4tGujWQ4gMMASPEEKqgCpoeDO0WS691Eqbv/HKGvw6Vmw==",
-      "dev": true,
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-from-markdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.1.0.tgz",
-      "integrity": "sha512-Mex7IIeIKRpGYNNywpxTfPhfFBTxBL5IVacPMU6GjYF+EkIvy++19cBgxVFyHVd2JpC/chG2IKGqZLffoo7Q1g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
+      "integrity": "sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==",
       "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "mdast-util-to-string": "^3.1.0",
         "micromark": "^3.0.0",
         "micromark-util-decode-numeric-character-reference": "^1.0.0",
@@ -5117,7 +5179,6 @@
         "micromark-util-normalize-identifier": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.0",
-        "parse-entities": "^3.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
       },
@@ -5127,12 +5188,13 @@
       }
     },
     "node_modules/mdast-util-gfm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-1.0.0.tgz",
-      "integrity": "sha512-JY4qImsTqivQ0Gl3qvdaizCpomFaNrHnjEhNjNNKeNEA5jZHAJDYu1+yO4V9jn4/ti8GrKdAScaT4F71knoxsA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.0.tgz",
+      "integrity": "sha512-wMwejlTN3EQADPFuvxe8lmGsay3+f6gSJKdAHR6KBJzpcxvsjJSILB9K6u6G7eQLC7iOTyVIHYGui9uBc9r1Tg==",
       "dev": true,
       "dependencies": {
         "mdast-util-gfm-autolink-literal": "^1.0.0",
+        "mdast-util-gfm-footnote": "^1.0.0",
         "mdast-util-gfm-strikethrough": "^1.0.0",
         "mdast-util-gfm-table": "^1.0.0",
         "mdast-util-gfm-task-list-item": "^1.0.0"
@@ -5152,6 +5214,22 @@
         "ccount": "^2.0.0",
         "mdast-util-find-and-replace": "^2.0.0",
         "micromark-util-character": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.0.tgz",
+      "integrity": "sha512-qeg9YoS2YYP6OBmMyUFxKXb6BLwAsbGidIxgwDAXHIMYZQhIwe52L9BSJs+zP29Jp5nSERPkmG3tSwAN23/ZbQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "unist-util-visit": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5214,15 +5292,15 @@
       }
     },
     "node_modules/mdast-util-mdx-jsx": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-1.1.2.tgz",
-      "integrity": "sha512-1/bDUZvPGNVxiAjrVsehMZTaNomihpbIMoMr8/UcAQ4h7itDFhN93LtO9XzQPlEM+CMueCoRYGQfl7N+5R+8Mg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-1.2.0.tgz",
+      "integrity": "sha512-5+ot/kfxYd3ChgEMwsMUO71oAfYjyRI3pADEK4I7xTmWLGQ8Y7ghm1CG36zUoUvDPxMlIYwQV/9DYHAUWdG4dA==",
       "dev": true,
       "dependencies": {
         "@types/estree-jsx": "^0.0.1",
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.0.0",
-        "parse-entities": "^3.0.0",
+        "parse-entities": "^4.0.0",
         "stringify-entities": "^4.0.0",
         "unist-util-remove-position": "^4.0.0",
         "unist-util-stringify-position": "^3.0.0",
@@ -5269,9 +5347,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-11.3.0.tgz",
-      "integrity": "sha512-4o3Cli3hXPmm1LhB+6rqhfsIUBjnKFlIUZvudaermXB+4/KONdd/W4saWWkC+LBLbPMqhFSSTSRgafHsT5fVJw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.0.0.tgz",
+      "integrity": "sha512-BCeq0Bz103NJvmhB7gN0TDmKRT7x3auJmEp7NcYX1xpqZsQeA3JNLazLhFx6VQPqw30e2zes/coKPAiEqxxUuQ==",
       "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
@@ -5279,6 +5357,7 @@
         "@types/mdurl": "^1.0.0",
         "mdast-util-definitions": "^5.0.0",
         "mdurl": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
         "unist-builder": "^3.0.0",
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
@@ -5290,9 +5369,9 @@
       }
     },
     "node_modules/mdast-util-to-markdown": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.4.tgz",
-      "integrity": "sha512-Wive3NvrNS4OY5yYKBADdK1QSlbJUZyZ2ssanITUzNQ7sxMfBANTVjLrAA9BFXshaeG9G77xpOK/z+TTret5Hg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.6.tgz",
+      "integrity": "sha512-doJZmTEGagHypWvJ8ltinmwUsT9ZaNgNIQW6Gl7jNdsI1QZkTHTimYW561Niy2s8AEPAqEgV0dIh2UOVlSXUJA==",
       "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
@@ -5376,9 +5455,9 @@
       "integrity": "sha512-y0y6CUB9RLVsy3kfgayU28746QrNMpSm9O/AYGNsBgOkJr/X/Jk0VLGoO8Ude7Bpa8adywzF+MzXNZRFRsNPhg=="
     },
     "node_modules/micromark": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.8.tgz",
-      "integrity": "sha512-RXc/UmMhTW++rxDNbw045w1E2WS4u7Ixd4g8cp7vmMi8U+m8Ua2SZniz8nrWlNHFUJZJk/lW3m0n19z2RCauxA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.9.tgz",
+      "integrity": "sha512-aWPjuXAqiFab4+oKLjH1vSNQm8S9GMnnf5sFNLrQaIggGYMBcQ9CS0Tt7+BJH6hbyv783zk3vgDhaORl3K33IQ==",
       "dev": true,
       "funding": [
         {
@@ -5393,6 +5472,7 @@
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "micromark-core-commonmark": "^1.0.1",
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -5406,14 +5486,13 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
-        "parse-entities": "^3.0.0",
         "uvu": "^0.5.0"
       }
     },
     "node_modules/micromark-core-commonmark": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.4.tgz",
-      "integrity": "sha512-HAtoZisp1M/sQFuw2zoUKGo1pMKod7GSvdM6B2oBU0U2CEN5/C6Tmydmi1rmvEieEhGQsjMyiiSoYgxISNxGFA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.5.tgz",
+      "integrity": "sha512-ZNtWumX94lpiyAu/lxvth6I5+XzxF+BLVUB7u60XzOBy4RojrbZqrx0mcRmbfqEMO6489vyvDfIQNv5hdulrPg==",
       "dev": true,
       "funding": [
         {
@@ -5426,6 +5505,7 @@
         }
       ],
       "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
         "micromark-factory-destination": "^1.0.0",
         "micromark-factory-label": "^1.0.0",
         "micromark-factory-space": "^1.0.0",
@@ -5440,37 +5520,17 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
-        "parse-entities": "^3.0.0",
         "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-extension-footnote": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-footnote/-/micromark-extension-footnote-1.0.2.tgz",
-      "integrity": "sha512-sD7t/hooONLnbPYgcQpBcTjh7mPEcD2R/jRS5DLYDNm0XbngbaJZ01F1aI3v6VXVMdAu3XtFKUecNRlXbgGk/Q==",
-      "dev": true,
-      "dependencies": {
-        "micromark-core-commonmark": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-1.0.0.tgz",
-      "integrity": "sha512-OjqbQPL1Vec/4l5hnC8WnMNmWwgrT9JvzR2udqIGrGKecZsdwY9GAWZ5482CuD12SXuHNj8aS8epni6ip0Pwog==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.0.tgz",
+      "integrity": "sha512-yYPlZ48Ss8fRFSmlQP/QXt3/M6tEvawEVFO+jDPnFA3mGeVgzIyaeHgrIV/9AMFAjQhctKA47Bk8xBhcuaL74Q==",
       "dev": true,
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^1.0.0",
+        "micromark-extension-gfm-footnote": "^1.0.0",
         "micromark-extension-gfm-strikethrough": "^1.0.0",
         "micromark-extension-gfm-table": "^1.0.0",
         "micromark-extension-gfm-tagfilter": "^1.0.0",
@@ -5493,6 +5553,25 @@
         "micromark-util-sanitize-uri": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.0.2.tgz",
+      "integrity": "sha512-C6o+B7w1wDM4JjDJeHCTszFYF1q46imElNY6mfXsBfw4E91M9TvEEEt3sy0FbJmGVzdt1pqFVRYWT9ZZ0FjFuA==",
+      "dev": true,
+      "dependencies": {
+        "micromark-core-commonmark": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
         "uvu": "^0.5.0"
       },
       "funding": {
@@ -5566,9 +5645,9 @@
       }
     },
     "node_modules/micromark-extension-mdx-expression": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.2.tgz",
-      "integrity": "sha512-KbkM9D9x/ZOV6gLwaN8izl2ZMI3sg+C4JLuUSmd8zJ4Z2d3mSWrznJRLuXkZcyN9lLaRm4Dz2VPjae3AkC5X1A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.3.tgz",
+      "integrity": "sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==",
       "dev": true,
       "funding": [
         {
@@ -5655,9 +5734,9 @@
       }
     },
     "node_modules/micromark-factory-mdx-expression": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.4.tgz",
-      "integrity": "sha512-1mS1Cg/GmvvafgHQvxz4OqhcO1JGwzzTuGh1C8NIUrmnr6/3A1dJiAphHz7kJKI/b9WIr69Q8VswuwyWo576yQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.5.tgz",
+      "integrity": "sha512-1DSMCBeCUj4m01P8uYbNWvOsv+FtpDTcBUcDCdE06sENTBX54lndRs9neWOgsNWfLDm2EzCyNKiUaoJ+mWa/WA==",
       "dev": true,
       "funding": [
         {
@@ -5845,9 +5924,9 @@
       }
     },
     "node_modules/micromark-util-decode-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.1.tgz",
-      "integrity": "sha512-Wf3H6jLaO3iIlHEvblESXaKAr72nK7JtBbLLICPwuZc3eJkMcp4j8rJ5Xv1VbQWMCWWDvKUbVUbE2MfQNznwTA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
+      "integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
       "dev": true,
       "funding": [
         {
@@ -5860,10 +5939,10 @@
         }
       ],
       "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^1.0.0",
         "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "parse-entities": "^3.0.0"
+        "micromark-util-symbol": "^1.0.0"
       }
     },
     "node_modules/micromark-util-encode": {
@@ -6087,6 +6166,15 @@
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dependencies": {
         "dom-walk": "^0.1.0"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -8565,6 +8653,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -8603,15 +8700,16 @@
       }
     },
     "node_modules/parse-entities": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
-      "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.0.tgz",
+      "integrity": "sha512-5nk9Fn03x3rEhGaX1FU6IDwG/k+GxLXlFAkgrbM1asuAFl3BhdQWvASaIsmwWypRNcZKHPYnIuOSfIWEyEQnPQ==",
       "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "character-entities": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
         "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "is-alphanumerical": "^2.0.0",
         "is-decimal": "^2.0.0",
         "is-hexadecimal": "^2.0.0"
@@ -8639,9 +8737,9 @@
       }
     },
     "node_modules/parse-latin": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.3.0.tgz",
-      "integrity": "sha512-TYKL+K98dcAWoCw/Ac1yrPviU8Trk+/gmjQVaoWEFDZmVD4KRg6c/80xKqNNFQObo2mTONgF8trzAf2UTwKafw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-5.0.0.tgz",
+      "integrity": "sha512-Ht+4/+AUySMS5HKGAiQpBmkFsHSoGrj6Y83flLCa5OIBdtsVkO3UD4OtboJ0O0vZiOznH02x8qlwg9KLUVXuNg==",
       "dev": true,
       "dependencies": {
         "nlcst-to-string": "^2.0.0",
@@ -8673,6 +8771,15 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
@@ -8741,14 +8848,14 @@
       "integrity": "sha1-Hwla1I3Ki/ihyCWOAJIDGkTyLKU="
     },
     "node_modules/postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.4.tgz",
+      "integrity": "sha512-joU6fBsN6EIer28Lj6GDFoC/5yOZzLCfn0zHAn/MYXI7aPt4m4hK5KC5ovEZXy+lnCjmYIbQWngvju2ddyEr8Q==",
       "dev": true,
       "dependencies": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -8759,9 +8866,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.5.15",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.15.tgz",
-      "integrity": "sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.2.tgz",
+      "integrity": "sha512-ppDjurt75nSxyikpyali+uKwRl8CK9N6ntOPovGIEGQagjMLVzEgVqFEsUUyUrqyE9Ch90KE0jmFc9q2QcPLBA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -9456,6 +9563,35 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-slug": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-5.0.0.tgz",
+      "integrity": "sha512-jnYsFKxRh+/tQa1L+SU/ykAPGOSVCqd0BwaOBPUANcvCu8d0/SZB4IalJkdJ+n6d1eAAS2YkvjUPi+2EGYtfCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "github-slugger": "^1.1.1",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-heading-rank": "^2.0.0",
+        "hast-util-to-string": "^2.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug/node_modules/hast-util-has-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-2.0.0.tgz",
+      "integrity": "sha512-4Qf++8o5v14us4Muv3HRj+Er6wTNGA/N9uCaZMty4JWvyFKLdhULrv4KE1b65AthsSO9TXSZnjuxS8ecIyhb0w==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-stringify": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.2.tgz",
@@ -9471,31 +9607,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark-footnotes": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-4.0.1.tgz",
-      "integrity": "sha512-He6YzQFk/Wu2KgfjI80EyPXjt/G+WFaYfUH+xapqPQBdm3aTdEyzosXXv9a2FbTxGqgOfJ4q/TCB46v+wofRpQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-footnote": "^1.0.0",
-        "micromark-extension-footnote": "^1.0.0",
-        "unified": "^10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-gfm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-2.0.0.tgz",
-      "integrity": "sha512-waIv4Tjcd2CTUDxKRYzuPyIHw1FoX4H2GjXAzXV9PxQWb+dU4fJivd/FZ+nxyzPARrqTjMIkwIwPoWNbpBhjcQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
+      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
       "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
-        "mdast-util-gfm": "^1.0.0",
-        "micromark-extension-gfm": "^1.0.0",
+        "mdast-util-gfm": "^2.0.0",
+        "micromark-extension-gfm": "^2.0.0",
         "unified": "^10.0.0"
       },
       "funding": {
@@ -9519,14 +9639,14 @@
       }
     },
     "node_modules/remark-rehype": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-9.1.0.tgz",
-      "integrity": "sha512-oLa6YmgAYg19zb0ZrBACh40hpBLteYROaPLhBXzLgjqyHQrN+gVP9N/FJvfzuNNuzCutktkroXEZBrxAxKhh7Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.0.1.tgz",
+      "integrity": "sha512-9itJLLOrbjrAi0qO5Rh0Wzi1d3eqvRvDWSsfif6W/BInVgCvzqSnB7BSfQRtb6MLfQiufXYG3NbbUqfE0p7nTA==",
       "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/mdast": "^3.0.0",
-        "mdast-util-to-hast": "^11.0.0",
+        "mdast-util-to-hast": "^12.0.0",
         "unified": "^10.0.0"
       },
       "funding": {
@@ -9534,22 +9654,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark-slug": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-7.0.1.tgz",
-      "integrity": "sha512-NRvYePr69LdeCkEGwL4KYAmq7kdWG5rEavCXMzUR4qndLoXHJAOLSUmPY6Qm4NJfKix7/EmgObyVaYivONAFhg==",
+    "node_modules/remark-smartypants": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-2.0.0.tgz",
+      "integrity": "sha512-Rc0VDmr/yhnMQIz8n2ACYXlfw/P/XZev884QU1I5u+5DgJls32o97Vc1RbK3pfumLsJomS2yy8eT4Fxj/2MDVA==",
       "dev": true,
       "dependencies": {
-        "@types/hast": "^2.3.2",
-        "@types/mdast": "^3.0.0",
-        "github-slugger": "^1.0.0",
-        "mdast-util-to-string": "^3.0.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0"
+        "retext": "^8.1.0",
+        "retext-smartypants": "^5.1.0",
+        "unist-util-visit": "^4.1.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/remark-stringify": {
@@ -9752,14 +9868,15 @@
       }
     },
     "node_modules/retext": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/retext/-/retext-7.0.1.tgz",
-      "integrity": "sha512-N0IaEDkvUjqyfn3/gwxVfI51IxfGzOiVXqPLWnKeCDbiQdxSg0zebzHPxXWnL7TeplAJ+RE4uqrXyYN//s9HjQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/retext/-/retext-8.1.0.tgz",
+      "integrity": "sha512-N9/Kq7YTn6ZpzfiGW45WfEGJqFf1IM1q8OsRa1CGzIebCJBNCANDRmOrholiDRGKo/We7ofKR4SEvcGAWEMD3Q==",
       "dev": true,
       "dependencies": {
-        "retext-latin": "^2.0.0",
-        "retext-stringify": "^2.0.0",
-        "unified": "^8.0.0"
+        "@types/nlcst": "^1.0.0",
+        "retext-latin": "^3.0.0",
+        "retext-stringify": "^3.0.0",
+        "unified": "^10.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9767,66 +9884,54 @@
       }
     },
     "node_modules/retext-latin": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-2.0.4.tgz",
-      "integrity": "sha512-fOoSSoQgDZ+l/uS81oxI3alBghDUPja0JEl0TpQxI6MN+dhM6fLFumPJwMZ4PJTyL5FFAgjlsdv8IX+6IRuwMw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-3.1.0.tgz",
+      "integrity": "sha512-5MrD1tuebzO8ppsja5eEu+ZbBeUNCjoEarn70tkXOS7Bdsdf6tNahsv2bY0Z8VooFF6cw7/6S+d3yI/TMlMVVQ==",
       "dev": true,
       "dependencies": {
-        "parse-latin": "^4.0.0",
-        "unherit": "^1.0.4"
+        "@types/nlcst": "^1.0.0",
+        "parse-latin": "^5.0.0",
+        "unherit": "^3.0.0",
+        "unified": "^10.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-latin/node_modules/unherit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-3.0.0.tgz",
+      "integrity": "sha512-UmvIQZGEc9qdLIQ8mv8/61n6PiMgfbOoASPKHpCvII5srShCQSa6jSjBjlZOR4bxt2XnT6uo6csmPKRi+zQ0Jg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/retext-smartypants": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-4.0.0.tgz",
-      "integrity": "sha512-Mknd05zuIycr4Z/hNDxA8ktqv7pG7wYdTZc68a2MJF+Ibg/WloR5bbyrEjijwNwHRR+xWsovkLH4OQIz/mghdw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-5.1.0.tgz",
+      "integrity": "sha512-P+VS0YlE96T2MRAlFHaTUhPrq1Rls+1GCvIytBvbo7wcgmRxC9xHle0/whTYpRqWirV9WaUm5mXmh1dKnskGWQ==",
       "dev": true,
       "dependencies": {
-        "nlcst-to-string": "^2.0.0",
-        "unist-util-visit": "^2.0.0"
+        "@types/nlcst": "^1.0.0",
+        "nlcst-to-string": "^3.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/retext-smartypants/node_modules/unist-util-is": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext-smartypants/node_modules/unist-util-visit": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+    "node_modules/retext-smartypants/node_modules/nlcst-to-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.0.tgz",
+      "integrity": "sha512-Y8HQWKw/zrHTCnu2zcFBN1dV6vN0NUG7s5fkEj380G8tF3R+vA2KG+tDl2QoHVQCTHGHVXwoni2RQkDSFQb1PA==",
       "dev": true,
       "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext-smartypants/node_modules/unist-util-visit-parents": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0"
+        "@types/nlcst": "^1.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9834,101 +9939,27 @@
       }
     },
     "node_modules/retext-stringify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-2.0.4.tgz",
-      "integrity": "sha512-xOtx5mFJBoT3j7PBtiY2I+mEGERNniofWktI1cKXvjMEJPOuqve0dghLHO1+gz/gScLn4zqspDGv4kk2wS5kSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-3.1.0.tgz",
+      "integrity": "sha512-767TLOaoXFXyOnjx/EggXlb37ZD2u4P1n0GJqVdpipqACsQP+20W+BNpMYrlJkq7hxffnFk+jc6mAK9qrbuB8w==",
       "dev": true,
       "dependencies": {
-        "nlcst-to-string": "^2.0.0"
+        "@types/nlcst": "^1.0.0",
+        "nlcst-to-string": "^3.0.0",
+        "unified": "^10.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/retext/node_modules/bail": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/retext/node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/retext/node_modules/trough": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/retext/node_modules/unified": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-      "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+    "node_modules/retext-stringify/node_modules/nlcst-to-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.0.tgz",
+      "integrity": "sha512-Y8HQWKw/zrHTCnu2zcFBN1dV6vN0NUG7s5fkEj380G8tF3R+vA2KG+tDl2QoHVQCTHGHVXwoni2RQkDSFQb1PA==",
       "dev": true,
       "dependencies": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^2.0.0",
-        "trough": "^1.0.0",
-        "vfile": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext/node_modules/unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext/node_modules/vfile": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/retext/node_modules/vfile-message": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
+        "@types/nlcst": "^1.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9945,10 +9976,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/rollup": {
-      "version": "2.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.0.tgz",
-      "integrity": "sha512-cHdv9GWd58v58rdseC8e8XIaPUo8a9cgZpnCMMDGZFDZKEODOiPPEQFXLriWr/TjXzhPPmG5bkAztPsOARIcGQ==",
+      "version": "2.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.1.tgz",
+      "integrity": "sha512-akwfnpjY0rXEDSn1UTVfKXJhPsEBu+imi1gqBA1ZkHGydUnkV/fWCC90P7rDaLEW8KTwBcS1G3N4893Ndz+jwg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -10012,6 +10055,30 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+      "dev": true,
+      "dependencies": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      }
+    },
+    "node_modules/sander/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/sanitize-filename": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -10021,9 +10088,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.43.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.4.tgz",
-      "integrity": "sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==",
+      "version": "1.43.5",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.5.tgz",
+      "integrity": "sha512-WuNm+eAryMgQluL7Mbq9M4EruyGGMyal7Lu58FfnRMVWxgUzIvI7aSn60iNt3kn5yZBMR7G84fAGDcwqOF5JOg==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -10397,6 +10464,21 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-0.0.3.tgz",
       "integrity": "sha512-r0SSA5Y5IWERF9Xh++tFPx0jITBgGggOsRLDWWew6YRw/C2dr4uNO1fw1vanrBmHsICmPyMLNBZboTlxUmUuaA=="
     },
+    "node_modules/sorcery": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
+      },
+      "bin": {
+        "sorcery": "bin/index.js"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -10406,9 +10488,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
+      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10629,6 +10711,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strnum": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.4.tgz",
@@ -10669,9 +10763,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.44.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.1.tgz",
-      "integrity": "sha512-4DrCEJoBvdR689efHNSxIQn2pnFwB7E7j2yLEJtHE/P8hxwZWIphCtJ8are7bjl/iVMlcEf5uh5pJ68IwR09vQ==",
+      "version": "3.44.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.2.tgz",
+      "integrity": "sha512-jrZhZtmH3ZMweXg1Q15onb8QlWD+a5T5Oca4C1jYvSURp2oD35h4A5TV6t6MEa93K4LlX6BkafZPdQoFjw/ylA==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -10684,6 +10778,72 @@
       "dev": true,
       "peerDependencies": {
         "svelte": ">=3.19.0"
+      }
+    },
+    "node_modules/svelte-preprocess": {
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.9.8.tgz",
+      "integrity": "sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/pug": "^2.0.4",
+        "@types/sass": "^1.16.0",
+        "detect-indent": "^6.0.0",
+        "magic-string": "^0.25.7",
+        "sorcery": "^0.10.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 9.11.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.2",
+        "coffeescript": "^2.5.1",
+        "less": "^3.11.3",
+        "postcss": "^7 || ^8",
+        "postcss-load-config": "^2.1.0 || ^3.0.0",
+        "pug": "^3.0.0",
+        "sass": "^1.26.8",
+        "stylus": "^0.54.7",
+        "sugarss": "^2.0.0",
+        "svelte": "^3.23.0",
+        "typescript": "^3.9.5 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "coffeescript": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "postcss-load-config": {
+          "optional": true
+        },
+        "pug": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/symbol-observable": {
@@ -11409,7 +11569,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.14.tgz",
       "integrity": "sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.13.2",
         "postcss": "^8.3.8",
@@ -11567,16 +11726,16 @@
       "dev": true
     },
     "node_modules/vue": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.22.tgz",
-      "integrity": "sha512-KD5nZpXVZquOC6926Xnp3zOvswrUyO9Rya7ZUoxWFQEjFDW4iACtwzubRB4Um2Om9kj6CaJOqAVRDSFlqLpdgw==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.23.tgz",
+      "integrity": "sha512-MGp9JZC37lzGhwSu6c1tQxrQbXbw7XKFqtYh7SFwNrNK899FPxGAHwSHMZijMChTSC3uZrD2BGO/3EHOgMJ0cw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/compiler-sfc": "3.2.22",
-        "@vue/runtime-dom": "3.2.22",
-        "@vue/server-renderer": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/compiler-dom": "3.2.23",
+        "@vue/compiler-sfc": "3.2.23",
+        "@vue/runtime-dom": "3.2.23",
+        "@vue/server-renderer": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "node_modules/warning": {
@@ -11698,6 +11857,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
     "node_modules/x-is-string": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
@@ -11775,9 +11940,9 @@
   },
   "dependencies": {
     "@astrojs/compiler": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.3.3.tgz",
-      "integrity": "sha512-iARMoTw6RgpLZyHoJPE34FSVphMZDGJ6U7FCqSErGfRzLhL6YY4o/UT4woqZ5yjcPLnoArNEx/KQfAYB07Stsw==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.3.9.tgz",
+      "integrity": "sha512-TzmIzpB6bpGD3vghcj+cXPckXkRCf6zHcVupf6F2b9WpFkMAvrXoafkKJIids2Mq9aU4p7ooVcIDGZ9tpqZpyw==",
       "dev": true,
       "requires": {
         "typescript": "^4.3.5"
@@ -11810,43 +11975,42 @@
       }
     },
     "@astrojs/markdown-remark": {
-      "version": "0.4.0-next.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-0.4.0-next.2.tgz",
-      "integrity": "sha512-mk/fOALeQR9xOwz2I03Sz391sx+vpt+ySW+oe8oQ5c3y8VYddeZEBNOrQv+lp5cgG+3c5AT5pP9LhbLB1r8Rmw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-0.5.0.tgz",
+      "integrity": "sha512-2A+PNNZ1w/GOZeLGRBco8QO6o3R8xtJY5EbQXwP3KmZ8xQZuVsZxX4HFpkFOvzm7ADCHZr7h6yVSdaoOAUb6UQ==",
       "dev": true,
       "requires": {
-        "@astrojs/prism": "^0.3.0-next.0",
-        "@silvenon/remark-smartypants": "^1.0.0",
+        "@astrojs/prism": "^0.3.0",
         "assert": "^2.0.0",
-        "github-slugger": "^1.3.0",
+        "github-slugger": "^1.4.0",
         "gray-matter": "^4.0.3",
         "mdast-util-mdx-expression": "^1.1.1",
-        "mdast-util-mdx-jsx": "^1.1.1",
-        "micromark-extension-mdx-expression": "^1.0.0",
-        "micromark-extension-mdx-jsx": "^1.0.0",
+        "mdast-util-mdx-jsx": "^1.1.3",
+        "micromark-extension-mdx-expression": "^1.0.3",
+        "micromark-extension-mdx-jsx": "^1.0.2",
         "prismjs": "^1.25.0",
-        "rehype-raw": "^6.0.0",
-        "rehype-stringify": "^9.0.1",
-        "remark-footnotes": "^4.0.1",
-        "remark-gfm": "^2.0.0",
-        "remark-parse": "^10.0.0",
-        "remark-rehype": "^9.0.0",
-        "remark-slug": "^7.0.0",
-        "unified": "^10.1.0",
+        "rehype-raw": "^6.1.0",
+        "rehype-slug": "^5.0.0",
+        "rehype-stringify": "^9.0.2",
+        "remark-gfm": "^3.0.1",
+        "remark-parse": "^10.0.1",
+        "remark-rehype": "^10.0.1",
+        "remark-smartypants": "^2.0.0",
+        "unified": "^10.1.1",
         "unist-util-map": "^3.0.0",
-        "unist-util-visit": "^4.0.0"
+        "unist-util-visit": "^4.1.0"
       }
     },
     "@astrojs/prism": {
-      "version": "0.3.0-next.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-0.3.0-next.0.tgz",
-      "integrity": "sha512-GNw7H5wA8Y9MjKxcilB6hMf0hSN1pwoLQE7HCMDUt0xOHW2JWuRSoVeIsu5+XLD5XnAXUcQij7M+xMu36N/tPg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-0.3.0.tgz",
+      "integrity": "sha512-5U+jcgfibLKW8PwnHQEdmgb+uZVeMVLz+paEr3vxKgikYfjXDjQu6qEDLOW3WTc/cIWrOF9rAtTKy8R/ArPscw==",
       "dev": true
     },
     "@astrojs/renderer-preact": {
-      "version": "0.3.0-next.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/renderer-preact/-/renderer-preact-0.3.0-next.1.tgz",
-      "integrity": "sha512-GWt3iphGKlstJQSPAwj5/3OPi1IOpEpnjeiW0qw+n2xy1aHTmdP9/BMvDvJFiQgIXl7hc+P82rU4yKz5znMPOQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/renderer-preact/-/renderer-preact-0.3.0.tgz",
+      "integrity": "sha512-gw+LpSdJXeSXdMTc9aIvVHiOyBs9w37D1yGogE/cleStIN9nTM6TVeU06gtZkIHOViOGAsMXTCrM7enr6VBMKQ==",
       "dev": true,
       "requires": {
         "@babel/plugin-transform-react-jsx": "^7.16.0",
@@ -11855,9 +12019,9 @@
       }
     },
     "@astrojs/renderer-react": {
-      "version": "0.3.0-next.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/renderer-react/-/renderer-react-0.3.0-next.1.tgz",
-      "integrity": "sha512-m3samDo32cIFqANyHv2RBQzM4zwN4a8hdxaZ0H9kWeux0ggSKQVIiYMJvRe84IR9CbHs2hFHtaszK4FdxD2/mg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/renderer-react/-/renderer-react-0.3.0.tgz",
+      "integrity": "sha512-pb9gKVHJwtFNoYrtSnBfOPm/0IerEGe6MCDrgys5lwVPWiZ9Di+7uK+C2/UdBuHDM8NEKw+zXA+6qZi/endy+g==",
       "dev": true,
       "requires": {
         "@babel/plugin-transform-react-jsx": "^7.16.0",
@@ -11866,19 +12030,20 @@
       }
     },
     "@astrojs/renderer-svelte": {
-      "version": "0.2.0-next.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/renderer-svelte/-/renderer-svelte-0.2.0-next.1.tgz",
-      "integrity": "sha512-BJ4OtP7pH8yk7XZIJ0f2QOZ7aP24NeAEuS7pfKyOyYZ0DL+qXUGzSlE/XYAwZtGW3ph6Nzsh6VK0woYOtBsrOw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/renderer-svelte/-/renderer-svelte-0.2.1.tgz",
+      "integrity": "sha512-0pifE/w+K6eLrDT0urBYPOBJzF7e4sL3+td7o1p4a3yGXPQsr5eKKQ66lyIKl7sgg5bXOVQhVMQbnm6rGqHxVA==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
-        "svelte": "^3.44.1"
+        "svelte": "^3.44.2",
+        "svelte-preprocess": "^4.9.8"
       }
     },
     "@astrojs/renderer-vue": {
-      "version": "0.2.0-next.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/renderer-vue/-/renderer-vue-0.2.0-next.2.tgz",
-      "integrity": "sha512-Px3MRkjQF3qikBA6p0UdaOr42VUPRMIUWsBbdGQk+LeNVmUnmQuhBwBS5qy+i+DXaS+JnOIMK01SU0klTLTE2Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/renderer-vue/-/renderer-vue-0.2.0.tgz",
+      "integrity": "sha512-YfQwghT0/n/tNbi/93wWsqNUwUxRCi76CdNvBRNyP01JVTZisQyqtT8yOJYGgMgqxQEscpPmD467dK89knd5gQ==",
       "dev": true,
       "requires": {
         "@vitejs/plugin-vue": "^1.9.4",
@@ -12516,46 +12681,6 @@
         "picomatch": "^2.2.2"
       }
     },
-    "@silvenon/remark-smartypants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@silvenon/remark-smartypants/-/remark-smartypants-1.0.0.tgz",
-      "integrity": "sha512-+Icx9z8zKBdO9mMcsUkfRbzGkHDXmv+Q4TyoPTiuhTrWK2UtLUglfTB5iRacuYHzNYKC4hJIJmTlC5c7fNxOiw==",
-      "dev": true,
-      "requires": {
-        "retext": "^7.0.1",
-        "retext-smartypants": "^4.0.0",
-        "unist-util-visit": "^2.0.1"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-          "dev": true
-        },
-        "unist-util-visit": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-          "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0",
-            "unist-util-visit-parents": "^3.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-          "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0"
-          }
-        }
-      }
-    },
     "@snowpack/plugin-dotenv": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@snowpack/plugin-dotenv/-/plugin-dotenv-2.2.0.tgz",
@@ -12709,6 +12834,15 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
+    "@types/nlcst": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-1.0.0.tgz",
+      "integrity": "sha512-3TGCfOcy8R8mMQ4CNSNOe3PG66HttvjcLzCoOpvXvDtfWOTi+uT/rxeOKm/qEwbM4SNe1O/PjdiBK2YcTjU4OQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/node": {
       "version": "16.11.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
@@ -12729,6 +12863,12 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
+    "@types/pug": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.5.tgz",
+      "integrity": "sha512-LOnASQoeNZMkzexRuyqcBBDZ6rS+rQxUMkmj5A0PkhhiSZivLIuz6Hxyr1mkGoEZEkk66faROmpMi4fFkrKsBA==",
+      "dev": true
     },
     "@types/react": {
       "version": "17.0.34",
@@ -12764,6 +12904,15 @@
       "integrity": "sha512-Ku5+GPFa12S3W26Uwtw+xyrtIpaZsGYHH6zxNbZlstmlvMYSZRzOwzwsXbxlVUbHyUucctSyuFtu6bNxwYomIw==",
       "dev": true
     },
+    "@types/sass": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
+      "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -12798,20 +12947,20 @@
       "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "@vitejs/plugin-vue": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.9.4.tgz",
-      "integrity": "sha512-0CZqaCoChriPTTtGkERy1LGPcYjGFpi2uYRhBPIkqJqUGV5JnJFhQAgh6oH9j5XZHfrRaisX8W0xSpO4T7S78A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.10.1.tgz",
+      "integrity": "sha512-oL76QETMSpVE9jIScirGB2bYJEVU/+r+g+K7oG+sXPs9TZljqveoVRsmLyXlMZTjpQkLL8gz527cW80NMGVKJg==",
       "dev": true,
       "requires": {}
     },
     "@vue/compiler-core": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-      "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.23.tgz",
+      "integrity": "sha512-4ZhiI/orx+7EJ1B+0zjgvXMV2uRN+XBfG06UN2sJfND9rH5gtEQT3QmO4erum1o6Irl7y754W8/KSaDJh4EUQg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.22",
+        "@vue/shared": "3.2.23",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       },
@@ -12825,27 +12974,27 @@
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz",
-      "integrity": "sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.23.tgz",
+      "integrity": "sha512-X2Nw8QFc5lgoK3kio5ktM95nqmLUH+q+N/PbV4kCHzF1avqv/EGLnAhaaF0Iu4bewNvHJAAhhwPZFeoV/22nbw==",
       "dev": true,
       "requires": {
-        "@vue/compiler-core": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/compiler-core": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.22.tgz",
-      "integrity": "sha512-tWRQ5ge1tsTDhUwHgueicKJ8rYm6WUVAPTaIpFW3GSwZKcOEJ2rXdfkHFShNVGupeRALz2ET2H84OL0GeRxY0A==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.23.tgz",
+      "integrity": "sha512-Aw+pb50Q5zTjyvWod8mNKmYZDRGHJBptmNNWE+84ZxrzEztPgMz8cNYIzWGbwcFVkmJlhvioAMvKnB+LM/sjSA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.22",
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/compiler-ssr": "3.2.22",
-        "@vue/ref-transform": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@vue/compiler-core": "3.2.23",
+        "@vue/compiler-dom": "3.2.23",
+        "@vue/compiler-ssr": "3.2.23",
+        "@vue/ref-transform": "3.2.23",
+        "@vue/shared": "3.2.23",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
@@ -12861,72 +13010,72 @@
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.22.tgz",
-      "integrity": "sha512-Cl6aoLJtXzzBkk1sKod8S0WBJLts3+ugVC91d22gGpbkw/64WnF12tOZi7Rg54PPLi1NovqyNWPsLH/SAFcu+w==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.23.tgz",
+      "integrity": "sha512-Bqzn4jFyXPK1Ehqiq7e/czS8n62gtYF1Zfeu0DrR5uv+SBllh7LIvZjZU6+c8qbocAd3/T3I3gn2cZGmnDb6zg==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/compiler-dom": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "@vue/reactivity": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.22.tgz",
-      "integrity": "sha512-xNkLAItjI0xB+lFeDgKCrSItmrHTaAzSnt8LmdSCPQnDyarmzbi/u4ESQnckWvlL7lSRKiEaOvblaNyqAa7OnQ==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.23.tgz",
+      "integrity": "sha512-8RGVr/5Kpgb/EkCjgHXqttgA5IMc6n0lIXFY4TVbMkzdXrvaIhzBd7Te44oIDsTSYVKZLpfHd6/wEnuDqE8vFw==",
       "dev": true,
       "requires": {
-        "@vue/shared": "3.2.22"
+        "@vue/shared": "3.2.23"
       }
     },
     "@vue/ref-transform": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.22.tgz",
-      "integrity": "sha512-qalVWbq5xWWxLZ0L9OroBg/JZhzavQuCcDXblfErxyDEH6Xc5gIJ4feo1SVCICFzhAUgLgQTdSFLpgjBawbFpw==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.23.tgz",
+      "integrity": "sha512-gW0GD2PSAs/th7mC7tPB/UwpIQxclbApVtsDtscDmOJXb2+cdu60ny+SuHNgfrlUT/JqWKQHq7jFKO4woxLNaA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@vue/compiler-core": "3.2.23",
+        "@vue/shared": "3.2.23",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.22.tgz",
-      "integrity": "sha512-e7WOC55wmHPvmoVUk9VBe/Z9k5bJfWJfVIlkUkiADJn0bOgQD29oh/GS14Kb3aEJXIHLI17Em6+HxNut1sIh7Q==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.23.tgz",
+      "integrity": "sha512-wSI5lmY2kCGLf89iiygqxVh6/5bsawz78Me9n1x4U2bHnN0yf3PWyuhN0WgIE8VfEaF7e75E333uboNEIFjgkg==",
       "dev": true,
       "requires": {
-        "@vue/reactivity": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/reactivity": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.22.tgz",
-      "integrity": "sha512-w7VHYJoliLRTLc5beN77wxuOjla4v9wr2FF22xpZFYBmH4U1V7HkYhoHc1BTuNghI15CXT1tNIMhibI1nrQgdw==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.23.tgz",
+      "integrity": "sha512-z6lp0888NkLmxD9j2sGoll8Kb7J743s8s6w7GbiyUc4WZwm0KJ35B4qTFDMoIU0G7CatS6Z+yRTpPHc6srtByg==",
       "dev": true,
       "requires": {
-        "@vue/runtime-core": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@vue/runtime-core": "3.2.23",
+        "@vue/shared": "3.2.23",
         "csstype": "^2.6.8"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.22.tgz",
-      "integrity": "sha512-jCwbQgKPXiXoH9VS9F7K+gyEvEMrjutannwEZD1R8fQ9szmOTqC+RRbIY3Uf2ibQjZtZ8DV9a4FjxICvd9zZlQ==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.23.tgz",
+      "integrity": "sha512-mgQ2VAE5WjeZELJKNbwE69uiBNpN+3LyL0ZDki1bJWVwHD2fhPfx7pwyYuiucE81xz2LxVsyGxhKKUL997g8vw==",
       "dev": true,
       "requires": {
-        "@vue/compiler-ssr": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/compiler-ssr": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "@vue/shared": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
-      "integrity": "sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.23.tgz",
+      "integrity": "sha512-U+/Jefa0QfXUF2qVy9Dqlrb6HKJSr9/wJcM66wXmWcTOoqg7hOWzF4qruDle51pyF4x3wMn6TSH54UdjKjCKMA==",
       "dev": true
     },
     "@web/parse5-utils": {
@@ -13204,19 +13353,19 @@
       "dev": true
     },
     "astro": {
-      "version": "0.21.0-next.11",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-0.21.0-next.11.tgz",
-      "integrity": "sha512-+h7ylkmfN9r3A8V8WfHLyk9kS//vq0zCBnlEG16WljN5BNFKZkImxuCsLOGwQzvuGeyUkS52jLKJqN7lRTE8HA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-0.21.4.tgz",
+      "integrity": "sha512-LDGPBbRDb54NZxRKzYEypphyoyVY5WwL3Lg/i9DiUlYmojfm5q/tw8kRgVj+nP0VNrJ/SrzIeVgtJmXMhwa3UQ==",
       "dev": true,
       "requires": {
-        "@astrojs/compiler": "^0.3.3",
+        "@astrojs/compiler": "^0.3.9",
         "@astrojs/language-server": "^0.7.16",
-        "@astrojs/markdown-remark": "^0.4.0-next.2",
-        "@astrojs/prism": "0.3.0-next.0",
-        "@astrojs/renderer-preact": "^0.3.0-next.1",
-        "@astrojs/renderer-react": "0.3.0-next.1",
-        "@astrojs/renderer-svelte": "0.2.0-next.1",
-        "@astrojs/renderer-vue": "0.2.0-next.2",
+        "@astrojs/markdown-remark": "^0.5.0",
+        "@astrojs/prism": "0.3.0",
+        "@astrojs/renderer-preact": "^0.3.0",
+        "@astrojs/renderer-react": "0.3.0",
+        "@astrojs/renderer-svelte": "0.2.1",
+        "@astrojs/renderer-vue": "0.2.0",
         "@babel/core": "^7.15.8",
         "@babel/traverse": "^7.15.4",
         "@proload/core": "^0.2.1",
@@ -13230,10 +13379,12 @@
         "es-module-lexer": "^0.7.1",
         "esbuild": "0.13.7",
         "estree-util-value-to-estree": "^1.2.0",
+        "fast-glob": "^3.2.7",
         "fast-xml-parser": "^3.19.0",
         "html-entities": "^2.3.2",
         "htmlparser2": "^7.1.2",
         "kleur": "^4.1.4",
+        "magic-string": "^0.25.7",
         "mime": "^2.5.2",
         "morphdom": "^2.6.1",
         "node-fetch": "^3.0.0",
@@ -13241,10 +13392,10 @@
         "path-to-regexp": "^6.2.0",
         "postcss": "^8.3.8",
         "prismjs": "^1.25.0",
-        "remark-slug": "^7.0.0",
+        "rehype-slug": "^5.0.0",
         "resolve": "^1.20.0",
         "rollup": "^2.57.0",
-        "sass": "^1.43.3",
+        "sass": "^1.43.4",
         "semver": "^7.3.5",
         "send": "^0.17.1",
         "shiki": "^0.9.10",
@@ -13256,6 +13407,7 @@
         "strip-ansi": "^7.0.1",
         "supports-esm": "^1.0.0",
         "tsconfig-resolver": "^3.0.1",
+        "vite": "^2.6.10",
         "yargs-parser": "^20.2.9",
         "zod": "^3.8.1"
       },
@@ -13628,6 +13780,12 @@
         "picocolors": "^1.0.0"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -13920,6 +14078,15 @@
         "ms": "2.1.2"
       }
     },
+    "decode-named-character-reference": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.0.tgz",
+      "integrity": "sha512-KTiXDlRp9MMm/nlgI8rDGKoNNKiTJBl0RPjnBM680m2HlgJEA4JTASspK44lsvE4GQJildMRFp2HdEBiG+nqng==",
+      "dev": true,
+      "requires": {
+        "character-entities": "^2.0.0"
+      }
+    },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -13958,6 +14125,12 @@
       "requires": {
         "repeat-string": "^1.5.4"
       }
+    },
+    "detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true
     },
     "diacritics": {
       "version": "1.3.0",
@@ -14185,6 +14358,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
       "dev": true
     },
     "esbuild": {
@@ -14625,6 +14804,12 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -14685,6 +14870,20 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
       "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==",
       "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "glob-parent": {
       "version": "5.1.2",
@@ -14839,6 +15038,15 @@
       "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
       "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg=="
     },
+    "hast-util-heading-rank": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-2.1.0.tgz",
+      "integrity": "sha512-w+Rw20Q/iWp2Bcnr6uTrYU6/ftZLbHKhvc8nM26VIWpDqDMlku2iXUVTeOlsdoih/UKQhY7PHQ+vZ0Aqq8bxtQ==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^2.0.0"
+      }
+    },
     "hast-util-is-element": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.1.tgz",
@@ -14962,6 +15170,15 @@
         "property-information": "^6.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      }
+    },
+    "hast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^2.0.0"
       }
     },
     "hast-util-to-text": {
@@ -15092,6 +15309,16 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         }
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -15701,25 +15928,15 @@
         }
       }
     },
-    "mdast-util-footnote": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-footnote/-/mdast-util-footnote-1.0.0.tgz",
-      "integrity": "sha512-DBQervPt/8PZOebnKZu2dXsLXgKHfCirW5BIR824z4tGujWQ4gMMASPEEKqgCpoeDO0WS691Eqbv/HKGvw6Vmw==",
-      "dev": true,
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0"
-      }
-    },
     "mdast-util-from-markdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.1.0.tgz",
-      "integrity": "sha512-Mex7IIeIKRpGYNNywpxTfPhfFBTxBL5IVacPMU6GjYF+EkIvy++19cBgxVFyHVd2JpC/chG2IKGqZLffoo7Q1g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
+      "integrity": "sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==",
       "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "mdast-util-to-string": "^3.1.0",
         "micromark": "^3.0.0",
         "micromark-util-decode-numeric-character-reference": "^1.0.0",
@@ -15727,18 +15944,18 @@
         "micromark-util-normalize-identifier": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.0",
-        "parse-entities": "^3.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
       }
     },
     "mdast-util-gfm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-1.0.0.tgz",
-      "integrity": "sha512-JY4qImsTqivQ0Gl3qvdaizCpomFaNrHnjEhNjNNKeNEA5jZHAJDYu1+yO4V9jn4/ti8GrKdAScaT4F71knoxsA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.0.tgz",
+      "integrity": "sha512-wMwejlTN3EQADPFuvxe8lmGsay3+f6gSJKdAHR6KBJzpcxvsjJSILB9K6u6G7eQLC7iOTyVIHYGui9uBc9r1Tg==",
       "dev": true,
       "requires": {
         "mdast-util-gfm-autolink-literal": "^1.0.0",
+        "mdast-util-gfm-footnote": "^1.0.0",
         "mdast-util-gfm-strikethrough": "^1.0.0",
         "mdast-util-gfm-table": "^1.0.0",
         "mdast-util-gfm-task-list-item": "^1.0.0"
@@ -15754,6 +15971,18 @@
         "ccount": "^2.0.0",
         "mdast-util-find-and-replace": "^2.0.0",
         "micromark-util-character": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-footnote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.0.tgz",
+      "integrity": "sha512-qeg9YoS2YYP6OBmMyUFxKXb6BLwAsbGidIxgwDAXHIMYZQhIwe52L9BSJs+zP29Jp5nSERPkmG3tSwAN23/ZbQ==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "unist-util-visit": "^4.0.0"
       }
     },
     "mdast-util-gfm-strikethrough": {
@@ -15796,15 +16025,15 @@
       }
     },
     "mdast-util-mdx-jsx": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-1.1.2.tgz",
-      "integrity": "sha512-1/bDUZvPGNVxiAjrVsehMZTaNomihpbIMoMr8/UcAQ4h7itDFhN93LtO9XzQPlEM+CMueCoRYGQfl7N+5R+8Mg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-1.2.0.tgz",
+      "integrity": "sha512-5+ot/kfxYd3ChgEMwsMUO71oAfYjyRI3pADEK4I7xTmWLGQ8Y7ghm1CG36zUoUvDPxMlIYwQV/9DYHAUWdG4dA==",
       "dev": true,
       "requires": {
         "@types/estree-jsx": "^0.0.1",
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.0.0",
-        "parse-entities": "^3.0.0",
+        "parse-entities": "^4.0.0",
         "stringify-entities": "^4.0.0",
         "unist-util-remove-position": "^4.0.0",
         "unist-util-stringify-position": "^3.0.0",
@@ -15839,9 +16068,9 @@
       }
     },
     "mdast-util-to-hast": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-11.3.0.tgz",
-      "integrity": "sha512-4o3Cli3hXPmm1LhB+6rqhfsIUBjnKFlIUZvudaermXB+4/KONdd/W4saWWkC+LBLbPMqhFSSTSRgafHsT5fVJw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.0.0.tgz",
+      "integrity": "sha512-BCeq0Bz103NJvmhB7gN0TDmKRT7x3auJmEp7NcYX1xpqZsQeA3JNLazLhFx6VQPqw30e2zes/coKPAiEqxxUuQ==",
       "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
@@ -15849,6 +16078,7 @@
         "@types/mdurl": "^1.0.0",
         "mdast-util-definitions": "^5.0.0",
         "mdurl": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
         "unist-builder": "^3.0.0",
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
@@ -15856,9 +16086,9 @@
       }
     },
     "mdast-util-to-markdown": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.4.tgz",
-      "integrity": "sha512-Wive3NvrNS4OY5yYKBADdK1QSlbJUZyZ2ssanITUzNQ7sxMfBANTVjLrAA9BFXshaeG9G77xpOK/z+TTret5Hg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.6.tgz",
+      "integrity": "sha512-doJZmTEGagHypWvJ8ltinmwUsT9ZaNgNIQW6Gl7jNdsI1QZkTHTimYW561Niy2s8AEPAqEgV0dIh2UOVlSXUJA==",
       "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
@@ -15922,13 +16152,14 @@
       "integrity": "sha512-y0y6CUB9RLVsy3kfgayU28746QrNMpSm9O/AYGNsBgOkJr/X/Jk0VLGoO8Ude7Bpa8adywzF+MzXNZRFRsNPhg=="
     },
     "micromark": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.8.tgz",
-      "integrity": "sha512-RXc/UmMhTW++rxDNbw045w1E2WS4u7Ixd4g8cp7vmMi8U+m8Ua2SZniz8nrWlNHFUJZJk/lW3m0n19z2RCauxA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.9.tgz",
+      "integrity": "sha512-aWPjuXAqiFab4+oKLjH1vSNQm8S9GMnnf5sFNLrQaIggGYMBcQ9CS0Tt7+BJH6hbyv783zk3vgDhaORl3K33IQ==",
       "dev": true,
       "requires": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "micromark-core-commonmark": "^1.0.1",
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -15942,16 +16173,16 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
-        "parse-entities": "^3.0.0",
         "uvu": "^0.5.0"
       }
     },
     "micromark-core-commonmark": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.4.tgz",
-      "integrity": "sha512-HAtoZisp1M/sQFuw2zoUKGo1pMKod7GSvdM6B2oBU0U2CEN5/C6Tmydmi1rmvEieEhGQsjMyiiSoYgxISNxGFA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.5.tgz",
+      "integrity": "sha512-ZNtWumX94lpiyAu/lxvth6I5+XzxF+BLVUB7u60XzOBy4RojrbZqrx0mcRmbfqEMO6489vyvDfIQNv5hdulrPg==",
       "dev": true,
       "requires": {
+        "decode-named-character-reference": "^1.0.0",
         "micromark-factory-destination": "^1.0.0",
         "micromark-factory-label": "^1.0.0",
         "micromark-factory-space": "^1.0.0",
@@ -15966,33 +16197,17 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
-        "parse-entities": "^3.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-extension-footnote": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-footnote/-/micromark-extension-footnote-1.0.2.tgz",
-      "integrity": "sha512-sD7t/hooONLnbPYgcQpBcTjh7mPEcD2R/jRS5DLYDNm0XbngbaJZ01F1aI3v6VXVMdAu3XtFKUecNRlXbgGk/Q==",
-      "dev": true,
-      "requires": {
-        "micromark-core-commonmark": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
         "uvu": "^0.5.0"
       }
     },
     "micromark-extension-gfm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-1.0.0.tgz",
-      "integrity": "sha512-OjqbQPL1Vec/4l5hnC8WnMNmWwgrT9JvzR2udqIGrGKecZsdwY9GAWZ5482CuD12SXuHNj8aS8epni6ip0Pwog==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.0.tgz",
+      "integrity": "sha512-yYPlZ48Ss8fRFSmlQP/QXt3/M6tEvawEVFO+jDPnFA3mGeVgzIyaeHgrIV/9AMFAjQhctKA47Bk8xBhcuaL74Q==",
       "dev": true,
       "requires": {
         "micromark-extension-gfm-autolink-literal": "^1.0.0",
+        "micromark-extension-gfm-footnote": "^1.0.0",
         "micromark-extension-gfm-strikethrough": "^1.0.0",
         "micromark-extension-gfm-table": "^1.0.0",
         "micromark-extension-gfm-tagfilter": "^1.0.0",
@@ -16011,6 +16226,21 @@
         "micromark-util-sanitize-uri": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-footnote": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.0.2.tgz",
+      "integrity": "sha512-C6o+B7w1wDM4JjDJeHCTszFYF1q46imElNY6mfXsBfw4E91M9TvEEEt3sy0FbJmGVzdt1pqFVRYWT9ZZ0FjFuA==",
+      "dev": true,
+      "requires": {
+        "micromark-core-commonmark": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
         "uvu": "^0.5.0"
       }
     },
@@ -16064,9 +16294,9 @@
       }
     },
     "micromark-extension-mdx-expression": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.2.tgz",
-      "integrity": "sha512-KbkM9D9x/ZOV6gLwaN8izl2ZMI3sg+C4JLuUSmd8zJ4Z2d3mSWrznJRLuXkZcyN9lLaRm4Dz2VPjae3AkC5X1A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.3.tgz",
+      "integrity": "sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==",
       "dev": true,
       "requires": {
         "micromark-factory-mdx-expression": "^1.0.0",
@@ -16119,9 +16349,9 @@
       }
     },
     "micromark-factory-mdx-expression": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.4.tgz",
-      "integrity": "sha512-1mS1Cg/GmvvafgHQvxz4OqhcO1JGwzzTuGh1C8NIUrmnr6/3A1dJiAphHz7kJKI/b9WIr69Q8VswuwyWo576yQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.5.tgz",
+      "integrity": "sha512-1DSMCBeCUj4m01P8uYbNWvOsv+FtpDTcBUcDCdE06sENTBX54lndRs9neWOgsNWfLDm2EzCyNKiUaoJ+mWa/WA==",
       "dev": true,
       "requires": {
         "micromark-factory-space": "^1.0.0",
@@ -16219,15 +16449,15 @@
       }
     },
     "micromark-util-decode-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.1.tgz",
-      "integrity": "sha512-Wf3H6jLaO3iIlHEvblESXaKAr72nK7JtBbLLICPwuZc3eJkMcp4j8rJ5Xv1VbQWMCWWDvKUbVUbE2MfQNznwTA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
+      "integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
       "dev": true,
       "requires": {
+        "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^1.0.0",
         "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "parse-entities": "^3.0.0"
+        "micromark-util-symbol": "^1.0.0"
       }
     },
     "micromark-util-encode": {
@@ -16347,6 +16577,12 @@
       "requires": {
         "dom-walk": "^0.1.0"
       }
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -18063,6 +18299,15 @@
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
     "one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -18098,15 +18343,16 @@
       }
     },
     "parse-entities": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
-      "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.0.tgz",
+      "integrity": "sha512-5nk9Fn03x3rEhGaX1FU6IDwG/k+GxLXlFAkgrbM1asuAFl3BhdQWvASaIsmwWypRNcZKHPYnIuOSfIWEyEQnPQ==",
       "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "character-entities": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
         "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "is-alphanumerical": "^2.0.0",
         "is-decimal": "^2.0.0",
         "is-hexadecimal": "^2.0.0"
@@ -18124,9 +18370,9 @@
       }
     },
     "parse-latin": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.3.0.tgz",
-      "integrity": "sha512-TYKL+K98dcAWoCw/Ac1yrPviU8Trk+/gmjQVaoWEFDZmVD4KRg6c/80xKqNNFQObo2mTONgF8trzAf2UTwKafw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-5.0.0.tgz",
+      "integrity": "sha512-Ht+4/+AUySMS5HKGAiQpBmkFsHSoGrj6Y83flLCa5OIBdtsVkO3UD4OtboJ0O0vZiOznH02x8qlwg9KLUVXuNg==",
       "dev": true,
       "requires": {
         "nlcst-to-string": "^2.0.0",
@@ -18150,6 +18396,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-parse": {
@@ -18201,20 +18453,20 @@
       "integrity": "sha1-Hwla1I3Ki/ihyCWOAJIDGkTyLKU="
     },
     "postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.4.tgz",
+      "integrity": "sha512-joU6fBsN6EIer28Lj6GDFoC/5yOZzLCfn0zHAn/MYXI7aPt4m4hK5KC5ovEZXy+lnCjmYIbQWngvju2ddyEr8Q==",
       "dev": true,
       "requires": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.1"
       }
     },
     "preact": {
-      "version": "10.5.15",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.15.tgz",
-      "integrity": "sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.2.tgz",
+      "integrity": "sha512-ppDjurt75nSxyikpyali+uKwRl8CK9N6ntOPovGIEGQagjMLVzEgVqFEsUUyUrqyE9Ch90KE0jmFc9q2QcPLBA==",
       "dev": true
     },
     "preact-render-to-string": {
@@ -18742,6 +18994,29 @@
         "hast-util-to-mdast": "^7.0.0"
       }
     },
+    "rehype-slug": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-5.0.0.tgz",
+      "integrity": "sha512-jnYsFKxRh+/tQa1L+SU/ykAPGOSVCqd0BwaOBPUANcvCu8d0/SZB4IalJkdJ+n6d1eAAS2YkvjUPi+2EGYtfCQ==",
+      "dev": true,
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "github-slugger": "^1.1.1",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-heading-rank": "^2.0.0",
+        "hast-util-to-string": "^2.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "dependencies": {
+        "hast-util-has-property": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-2.0.0.tgz",
+          "integrity": "sha512-4Qf++8o5v14us4Muv3HRj+Er6wTNGA/N9uCaZMty4JWvyFKLdhULrv4KE1b65AthsSO9TXSZnjuxS8ecIyhb0w==",
+          "dev": true
+        }
+      }
+    },
     "rehype-stringify": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.2.tgz",
@@ -18753,27 +19028,15 @@
         "unified": "^10.0.0"
       }
     },
-    "remark-footnotes": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-4.0.1.tgz",
-      "integrity": "sha512-He6YzQFk/Wu2KgfjI80EyPXjt/G+WFaYfUH+xapqPQBdm3aTdEyzosXXv9a2FbTxGqgOfJ4q/TCB46v+wofRpQ==",
-      "dev": true,
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-footnote": "^1.0.0",
-        "micromark-extension-footnote": "^1.0.0",
-        "unified": "^10.0.0"
-      }
-    },
     "remark-gfm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-2.0.0.tgz",
-      "integrity": "sha512-waIv4Tjcd2CTUDxKRYzuPyIHw1FoX4H2GjXAzXV9PxQWb+dU4fJivd/FZ+nxyzPARrqTjMIkwIwPoWNbpBhjcQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
+      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
       "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
-        "mdast-util-gfm": "^1.0.0",
-        "micromark-extension-gfm": "^1.0.0",
+        "mdast-util-gfm": "^2.0.0",
+        "micromark-extension-gfm": "^2.0.0",
         "unified": "^10.0.0"
       }
     },
@@ -18789,29 +19052,26 @@
       }
     },
     "remark-rehype": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-9.1.0.tgz",
-      "integrity": "sha512-oLa6YmgAYg19zb0ZrBACh40hpBLteYROaPLhBXzLgjqyHQrN+gVP9N/FJvfzuNNuzCutktkroXEZBrxAxKhh7Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.0.1.tgz",
+      "integrity": "sha512-9itJLLOrbjrAi0qO5Rh0Wzi1d3eqvRvDWSsfif6W/BInVgCvzqSnB7BSfQRtb6MLfQiufXYG3NbbUqfE0p7nTA==",
       "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/mdast": "^3.0.0",
-        "mdast-util-to-hast": "^11.0.0",
+        "mdast-util-to-hast": "^12.0.0",
         "unified": "^10.0.0"
       }
     },
-    "remark-slug": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-7.0.1.tgz",
-      "integrity": "sha512-NRvYePr69LdeCkEGwL4KYAmq7kdWG5rEavCXMzUR4qndLoXHJAOLSUmPY6Qm4NJfKix7/EmgObyVaYivONAFhg==",
+    "remark-smartypants": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-2.0.0.tgz",
+      "integrity": "sha512-Rc0VDmr/yhnMQIz8n2ACYXlfw/P/XZev884QU1I5u+5DgJls32o97Vc1RbK3pfumLsJomS2yy8eT4Fxj/2MDVA==",
       "dev": true,
       "requires": {
-        "@types/hast": "^2.3.2",
-        "@types/mdast": "^3.0.0",
-        "github-slugger": "^1.0.0",
-        "mdast-util-to-string": "^3.0.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0"
+        "retext": "^8.1.0",
+        "retext-smartypants": "^5.1.0",
+        "unist-util-visit": "^4.1.0"
       }
     },
     "remark-stringify": {
@@ -18964,136 +19224,80 @@
       }
     },
     "retext": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/retext/-/retext-7.0.1.tgz",
-      "integrity": "sha512-N0IaEDkvUjqyfn3/gwxVfI51IxfGzOiVXqPLWnKeCDbiQdxSg0zebzHPxXWnL7TeplAJ+RE4uqrXyYN//s9HjQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/retext/-/retext-8.1.0.tgz",
+      "integrity": "sha512-N9/Kq7YTn6ZpzfiGW45WfEGJqFf1IM1q8OsRa1CGzIebCJBNCANDRmOrholiDRGKo/We7ofKR4SEvcGAWEMD3Q==",
       "dev": true,
       "requires": {
-        "retext-latin": "^2.0.0",
-        "retext-stringify": "^2.0.0",
-        "unified": "^8.0.0"
-      },
-      "dependencies": {
-        "bail": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-          "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        },
-        "trough": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-          "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-          "dev": true
-        },
-        "unified": {
-          "version": "8.4.2",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-          "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
-          "dev": true,
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-plain-obj": "^2.0.0",
-            "trough": "^1.0.0",
-            "vfile": "^4.0.0"
-          }
-        },
-        "unist-util-stringify-position": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.2"
-          }
-        },
-        "vfile": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-          "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "is-buffer": "^2.0.0",
-            "unist-util-stringify-position": "^2.0.0",
-            "vfile-message": "^2.0.0"
-          }
-        },
-        "vfile-message": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-          "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-stringify-position": "^2.0.0"
-          }
-        }
+        "@types/nlcst": "^1.0.0",
+        "retext-latin": "^3.0.0",
+        "retext-stringify": "^3.0.0",
+        "unified": "^10.0.0"
       }
     },
     "retext-latin": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-2.0.4.tgz",
-      "integrity": "sha512-fOoSSoQgDZ+l/uS81oxI3alBghDUPja0JEl0TpQxI6MN+dhM6fLFumPJwMZ4PJTyL5FFAgjlsdv8IX+6IRuwMw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-3.1.0.tgz",
+      "integrity": "sha512-5MrD1tuebzO8ppsja5eEu+ZbBeUNCjoEarn70tkXOS7Bdsdf6tNahsv2bY0Z8VooFF6cw7/6S+d3yI/TMlMVVQ==",
       "dev": true,
       "requires": {
-        "parse-latin": "^4.0.0",
-        "unherit": "^1.0.4"
+        "@types/nlcst": "^1.0.0",
+        "parse-latin": "^5.0.0",
+        "unherit": "^3.0.0",
+        "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "unherit": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unherit/-/unherit-3.0.0.tgz",
+          "integrity": "sha512-UmvIQZGEc9qdLIQ8mv8/61n6PiMgfbOoASPKHpCvII5srShCQSa6jSjBjlZOR4bxt2XnT6uo6csmPKRi+zQ0Jg==",
+          "dev": true
+        }
       }
     },
     "retext-smartypants": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-4.0.0.tgz",
-      "integrity": "sha512-Mknd05zuIycr4Z/hNDxA8ktqv7pG7wYdTZc68a2MJF+Ibg/WloR5bbyrEjijwNwHRR+xWsovkLH4OQIz/mghdw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-5.1.0.tgz",
+      "integrity": "sha512-P+VS0YlE96T2MRAlFHaTUhPrq1Rls+1GCvIytBvbo7wcgmRxC9xHle0/whTYpRqWirV9WaUm5mXmh1dKnskGWQ==",
       "dev": true,
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "unist-util-visit": "^2.0.0"
+        "@types/nlcst": "^1.0.0",
+        "nlcst-to-string": "^3.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0"
       },
       "dependencies": {
-        "unist-util-is": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-          "dev": true
-        },
-        "unist-util-visit": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-          "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+        "nlcst-to-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.0.tgz",
+          "integrity": "sha512-Y8HQWKw/zrHTCnu2zcFBN1dV6vN0NUG7s5fkEj380G8tF3R+vA2KG+tDl2QoHVQCTHGHVXwoni2RQkDSFQb1PA==",
           "dev": true,
           "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0",
-            "unist-util-visit-parents": "^3.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-          "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0"
+            "@types/nlcst": "^1.0.0"
           }
         }
       }
     },
     "retext-stringify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-2.0.4.tgz",
-      "integrity": "sha512-xOtx5mFJBoT3j7PBtiY2I+mEGERNniofWktI1cKXvjMEJPOuqve0dghLHO1+gz/gScLn4zqspDGv4kk2wS5kSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-3.1.0.tgz",
+      "integrity": "sha512-767TLOaoXFXyOnjx/EggXlb37ZD2u4P1n0GJqVdpipqACsQP+20W+BNpMYrlJkq7hxffnFk+jc6mAK9qrbuB8w==",
       "dev": true,
       "requires": {
-        "nlcst-to-string": "^2.0.0"
+        "@types/nlcst": "^1.0.0",
+        "nlcst-to-string": "^3.0.0",
+        "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "nlcst-to-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.0.tgz",
+          "integrity": "sha512-Y8HQWKw/zrHTCnu2zcFBN1dV6vN0NUG7s5fkEj380G8tF3R+vA2KG+tDl2QoHVQCTHGHVXwoni2RQkDSFQb1PA==",
+          "dev": true,
+          "requires": {
+            "@types/nlcst": "^1.0.0"
+          }
+        }
       }
     },
     "reusify": {
@@ -19102,10 +19306,19 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "rollup": {
-      "version": "2.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.0.tgz",
-      "integrity": "sha512-cHdv9GWd58v58rdseC8e8XIaPUo8a9cgZpnCMMDGZFDZKEODOiPPEQFXLriWr/TjXzhPPmG5bkAztPsOARIcGQ==",
+      "version": "2.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.1.tgz",
+      "integrity": "sha512-akwfnpjY0rXEDSn1UTVfKXJhPsEBu+imi1gqBA1ZkHGydUnkV/fWCC90P7rDaLEW8KTwBcS1G3N4893Ndz+jwg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -19146,6 +19359,29 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
+      }
+    },
     "sanitize-filename": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -19155,9 +19391,9 @@
       }
     },
     "sass": {
-      "version": "1.43.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.4.tgz",
-      "integrity": "sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==",
+      "version": "1.43.5",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.5.tgz",
+      "integrity": "sha512-WuNm+eAryMgQluL7Mbq9M4EruyGGMyal7Lu58FfnRMVWxgUzIvI7aSn60iNt3kn5yZBMR7G84fAGDcwqOF5JOg==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -19476,15 +19712,27 @@
       "integrity": "sha512-iTy2bl/G+tphN10YQBOPDRxDqgM46ZH1UUz0ublmL6PLtwJ3jJK1n08w37YxnY/ge4aW31UN386KV6qvFx6Hsw==",
       "requires": {}
     },
+    "sorcery": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
+      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
       "dev": true
     },
     "sourcemap-codec": {
@@ -19648,6 +19896,15 @@
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strnum": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.4.tgz",
@@ -19685,9 +19942,9 @@
       }
     },
     "svelte": {
-      "version": "3.44.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.1.tgz",
-      "integrity": "sha512-4DrCEJoBvdR689efHNSxIQn2pnFwB7E7j2yLEJtHE/P8hxwZWIphCtJ8are7bjl/iVMlcEf5uh5pJ68IwR09vQ==",
+      "version": "3.44.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.2.tgz",
+      "integrity": "sha512-jrZhZtmH3ZMweXg1Q15onb8QlWD+a5T5Oca4C1jYvSURp2oD35h4A5TV6t6MEa93K4LlX6BkafZPdQoFjw/ylA==",
       "dev": true
     },
     "svelte-hmr": {
@@ -19696,6 +19953,20 @@
       "integrity": "sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==",
       "dev": true,
       "requires": {}
+    },
+    "svelte-preprocess": {
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.9.8.tgz",
+      "integrity": "sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==",
+      "dev": true,
+      "requires": {
+        "@types/pug": "^2.0.4",
+        "@types/sass": "^1.16.0",
+        "detect-indent": "^6.0.0",
+        "magic-string": "^0.25.7",
+        "sorcery": "^0.10.0",
+        "strip-indent": "^3.0.0"
+      }
     },
     "symbol-observable": {
       "version": "1.2.0",
@@ -20250,7 +20521,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.14.tgz",
       "integrity": "sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "esbuild": "^0.13.2",
         "fsevents": "~2.3.2",
@@ -20381,16 +20651,16 @@
       "dev": true
     },
     "vue": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.22.tgz",
-      "integrity": "sha512-KD5nZpXVZquOC6926Xnp3zOvswrUyO9Rya7ZUoxWFQEjFDW4iACtwzubRB4Um2Om9kj6CaJOqAVRDSFlqLpdgw==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.23.tgz",
+      "integrity": "sha512-MGp9JZC37lzGhwSu6c1tQxrQbXbw7XKFqtYh7SFwNrNK899FPxGAHwSHMZijMChTSC3uZrD2BGO/3EHOgMJ0cw==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/compiler-sfc": "3.2.22",
-        "@vue/runtime-dom": "3.2.22",
-        "@vue/server-renderer": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/compiler-dom": "3.2.23",
+        "@vue/compiler-sfc": "3.2.23",
+        "@vue/runtime-dom": "3.2.23",
+        "@vue/server-renderer": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "warning": {
@@ -20488,6 +20758,12 @@
         "readable-stream": "^2.3.7",
         "triple-beam": "^1.2.0"
       }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@astrojs/renderer-react": "^0.3.0-next.1",
         "@snowpack/plugin-dotenv": "^2.1.0",
-        "astro": "^0.21.4",
+        "astro": "^0.21.5",
         "netlify-cms-proxy-server": "^1.3.22",
         "npm-run-all": "^4.1.5"
       }
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-0.21.4.tgz",
-      "integrity": "sha512-LDGPBbRDb54NZxRKzYEypphyoyVY5WwL3Lg/i9DiUlYmojfm5q/tw8kRgVj+nP0VNrJ/SrzIeVgtJmXMhwa3UQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-0.21.5.tgz",
+      "integrity": "sha512-rL06t9k1xsHjdP4sinQhfhuhLn+EqmgSjzsOTZP60BZIuE8gHnpchxqieoiOQZh6i/3u379cO816XLEPZCv43Q==",
       "dev": true,
       "dependencies": {
         "@astrojs/compiler": "^0.3.9",
@@ -13353,9 +13353,9 @@
       "dev": true
     },
     "astro": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-0.21.4.tgz",
-      "integrity": "sha512-LDGPBbRDb54NZxRKzYEypphyoyVY5WwL3Lg/i9DiUlYmojfm5q/tw8kRgVj+nP0VNrJ/SrzIeVgtJmXMhwa3UQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-0.21.5.tgz",
+      "integrity": "sha512-rL06t9k1xsHjdP4sinQhfhuhLn+EqmgSjzsOTZP60BZIuE8gHnpchxqieoiOQZh6i/3u379cO816XLEPZCv43Q==",
       "dev": true,
       "requires": {
         "@astrojs/compiler": "^0.3.9",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@astrojs/renderer-react": "^0.3.0-next.1",
     "@snowpack/plugin-dotenv": "^2.1.0",
-    "astro": "^0.21.0-next.11",
+    "astro": "^0.21.4",
     "netlify-cms-proxy-server": "^1.3.22",
     "npm-run-all": "^4.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@astrojs/renderer-react": "^0.3.0-next.1",
     "@snowpack/plugin-dotenv": "^2.1.0",
-    "astro": "^0.21.4",
+    "astro": "^0.21.5",
     "netlify-cms-proxy-server": "^1.3.22",
     "npm-run-all": "^4.1.5"
   }

--- a/src/components/Redirect.astro
+++ b/src/components/Redirect.astro
@@ -1,0 +1,5 @@
+---
+const {target} = Astro.props;
+---
+
+<head><meta http-equiv="refresh" content={`0; url=${target}`}></head>

--- a/src/data/docs/en/nebula.md
+++ b/src/data/docs/en/nebula.md
@@ -5,14 +5,14 @@ description: Learn about the Nebula open-source project from its creators. Find
   help you securely connect Linux, Mac, Windows, iOS, and Android hosts located
   on any network.
 slug: nebula
-summary: Here is where you'll find detail about each of the major components in
-  Nebula's architecture, how they fit together, and how to make them work best
+summary: Here is where you’ll find detail about each of the major components in
+  Nebula’s architecture, how they fit together, and how to make them work best
   in a variety of environments and use cases.
 ---
 
 # The Open Source Overlay Networking Tool
 
-Interested in creating an overlay network of your own? You're in the right place. Welcome!
+Interested in creating an overlay network of your own? You’re in the right place. Welcome!
 
 When Nebula was open sourced, we did our best to include clear and concise documentation within the README and configuration files published along with the source code.
 
@@ -20,7 +20,7 @@ When Nebula was open sourced, we did our best to include clear and concise docum
 
 After a few months of fielding questions about how to get Nebula working it became clear that we needed to expand the official documentation for the project.
 
-Here is where you'll find detail about each of the major components in Nebula's architecture, how they fit together, and how to make them work best in a variety of environments and use cases.
+Here is where you’ll find detail about each of the major components in Nebula’s architecture, how they fit together, and how to make them work best in a variety of environments and use cases.
 
 ## Learning about Nebula
 

--- a/src/data/docs/en/overview.md
+++ b/src/data/docs/en/overview.md
@@ -19,13 +19,13 @@ What makes Nebula different to existing offerings is that it brings all of these
 
 Our primary goal when creating Nebula was to allow seamless connectivity between any set of computers, regardless of where they are in the world. When enabling such connectivity, it is very important that users have the tooling to separate those computers from each other.
 
-### What's an overlay network?
+### What’s an overlay network?
 
 Put simply, an overlay network is a virtual network that runs on top of another network. A virtual Private Network (VPN) is an overlay network. A SSH tunnel is an overlay network. A SOCKS proxy is an overlay network. A Virtual Private Cloud (VPC) is an overlay network.
 
 Nebula was designed to be extensible: You can use it to secure traffic between two sites
 
-### So, it's a VPN?
+### So, it’s a VPN?
 
 You can use Nebula to replace an existing VPN, but it has features not present in most other solutions:
 

--- a/src/pages/[locale]/[slug].astro
+++ b/src/pages/[locale]/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../../layouts/MainLayout.astro';
 import ConfigReference from '../../components/ConfigReference.astro';
+import Redirect from '../../components/Redirect.astro';
 import {getLanguageFromFilename, getSlugFromFilename, DEFAULT_LOCALE, KNOWN_LANGUAGE_CODES} from '../../languages';
 
 export async function getStaticPaths() {
@@ -111,7 +112,7 @@ const isConfigRefPage = !redirect && page.canonicalSlug === 'config';
 ---
 
 {redirect 
-  ? <head><meta http-equiv="refresh" content={`0; url=${redirect}`}></head>
+  ? <Redirect target={redirect} />
   : <Layout content={page}>
       {page.html}
       {isConfigRefPage && <ConfigReference locale={locale}/>}


### PR DESCRIPTION
This updates to the latest stable version of astro (0.21.4), and fixes a bug which prevented extended unicode characters from displaying properly, re-adding curly apostrophes which were recently removed to work around that issue.

This also adds a link to the other known issue, in which the astro dev server does not load the page correctly on the first attempt.