### PR TITLE
Add table of contents to right sidebar

### DIFF
--- a/src/components/ConfigReference.astro
+++ b/src/components/ConfigReference.astro
@@ -22,7 +22,12 @@ const configOptions = options[locale] ? options[locale].options : fallbackOption
         description={option.description ?? fallbackOption.description}
         example={option.example ?? fallbackOption.example}
       >
-        <h2>{option.name}</h2>
+        <h2 id={option.name}>
+          {option.name}
+          <a aria-hidden="true" tabindex="-1" class="heading-link no-underline" href={`#${option.name}`}>
+            <span class="fas fa-link"></span>
+          </a>
+        </h2>
       </ConfigOption>
       {option.suboptions && option.suboptions.map((suboption, subIndex) => {
         const fallbackSuboption = fallbackOption.suboptions[subIndex];
@@ -32,7 +37,12 @@ const configOptions = options[locale] ? options[locale].options : fallbackOption
           description={suboption.description ?? fallbackSuboption.description}
           example={suboption.example ?? fallbackSuboption.example}
         >
-          <h3>{option.name}.{suboption.name}</h3>
+          <h3 id={`${option.name}-${suboption.name}`.replace(new RegExp(', ', 'g'), '-')}>
+            {option.name}.{suboption.name}
+            <a aria-hidden="true" tabindex="-1" class="heading-link no-underline" href={`#${option.name}-${suboption.name}`.replace(new RegExp(', ', 'g'), '-')}>
+              <span class="fas fa-link"></span>
+            </a>
+          </h3>
         </ConfigOption>)
       })}
     </div>

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -1,5 +1,6 @@
 ---
 import {getSections} from '../../get-page-links'
+import NavLink from '../Nav/NavLink.astro';
 
 const {currentPage} = Astro.props;
 const allPages = Astro.fetchContent('../../data/**/*.md');
@@ -10,7 +11,7 @@ const sections = getSections({currentPage, allPages})
 <nav aria-labelledby="grid-left">
   <ul class="nav-groups"> 
     {sections.map(section => (
-      <li class='nav-link section-header'>
+      <NavLink class="section-header">
         <a 
           href={section.root.href} 
           aria-current={`${currentPage === section.root.href ? 'page' : 'false'}`} 
@@ -21,15 +22,15 @@ const sections = getSections({currentPage, allPages})
           section.children && 
             <ul>
               {section.children.map(child => (
-                <li class="nav-link">
+                <NavLink>
                   <a href={child.href} aria-current={`${currentPage.replace(/\/$/, '') === child.href ? 'page' : 'false'}`}>
                     {child.title}
                   </a>
-                </li>
+                </NavLink>
               ))}
             </ul>
         }
-      </li>
+      </NavLink>
     ))}
   </ul>
 </nav>
@@ -52,23 +53,17 @@ const sections = getSections({currentPage, allPages})
   }
   .nav-groups {
     height: 100%;
-    padding: 2rem 0;
+    padding: 8px;
     overflow-x: visible;
     overflow-y: auto;
     max-height: 100vh;
+    // left-align with logo
+    margin-left: -24px;
   }
 
   .nav-groups > :last-child {
     padding-bottom: 2rem;
     margin-bottom: var(--theme-navbar-height);
-  }
-
-  .nav-link a {
-    font-size: 14px;
-    margin: 1px;
-    padding: 0.3rem 1rem;
-    color: inherit;
-    display: block;
   }
 
   .section-header > a {
@@ -77,22 +72,8 @@ const sections = getSections({currentPage, allPages})
     color: theme.$gray-200;
   }
 
-  .nav-link a[aria-current="page"],
   .section-header a[aria-current="page"] {
     color: var(--theme-accent-text);
-  }
-
-  .nav-link a:hover,
-  .nav-link a:focus {
-    color: white;
-  }
-
-  
-
-  @media (min-width: 992px) {
-    .nav-groups {
-      padding: 0;
-    }
   }
 
 </style>

--- a/src/components/Nav/NavLink.astro
+++ b/src/components/Nav/NavLink.astro
@@ -1,0 +1,30 @@
+---
+
+const className = Astro.props.class;
+
+---
+
+<style lang="scss">
+  @use "../../styles/theme.scss";
+
+  .nav-link :global(a) {
+    font-size: 14px;
+    margin: 1px;
+    padding: 0.3rem 1rem;
+    color: inherit;
+    display: block;
+  }
+
+  .nav-link :global(a)[aria-current="page"] {
+    color: var(--theme-accent-text);
+  }
+
+  .nav-link :global(a):hover,
+  .nav-link :global(a):focus {
+    color: white;
+  }
+</style>
+
+<li class={`nav-link ${className}`.trim()}>
+  <slot />
+</li>

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -1,0 +1,23 @@
+---
+import TOC from './TOC.astro';
+const {content} = Astro.props;
+const headers = content.content.headers;
+
+---
+<style>
+  .sidebar-nav {
+    width: 100%;
+    position: sticky;
+    top: 0;
+  }
+  .sidebar-nav-inner {
+    height: 100%;
+    padding: 0;
+    overflow: auto;
+  }
+</style>
+<nav class="sidebar-nav" aria-labelledby="grid-right">
+  <div class="sidebar-nav-inner">
+    {headers && <TOC headers={headers} />}
+  </div>
+</nav>

--- a/src/components/RightSidebar/TOC.astro
+++ b/src/components/RightSidebar/TOC.astro
@@ -1,0 +1,37 @@
+---
+import NavLink from '../Nav/NavLink.astro';
+const {headers} = Astro.props;
+
+---
+
+<style lang="scss">
+  .heading {
+    font-family: Inter;
+    font-size: 12px;
+    text-transform: uppercase;
+    color: var(--theme-text);
+    padding-left: calc(1rem + 8px);
+    margin-bottom: 4px;
+    // Align with left sidebar top
+    margin-top: 8px;
+  }
+
+  ul {
+    // For focus ring
+    padding: 8px;
+    overflow-x: visible;
+    overflow-y: auto;
+    max-height: 100vh;
+  }
+</style>
+
+<h2 class='heading'>On this page</h2>
+<ul>
+  {headers
+    .filter(({ depth }) => depth === 2)
+    .map((header) => (
+      <NavLink>
+        <a href={`#${header.slug}`}>{header.text}</a>
+      </NavLink>
+    ))}
+</ul>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -3,6 +3,7 @@ import HeadCommon from "../components/HeadCommon.astro";
 import Header from '../components/Header/Header.astro';
 import PageContent from '../components/PageContent/PageContent.astro';
 import LeftSidebar from '../components/LeftSidebar/LeftSidebar.astro';
+import RightSidebar from '../components/RightSidebar/RightSidebar.astro';
 import MobileNav from '../components/MobileNav.astro'
 import * as CONFIG from "../config";
 
@@ -57,11 +58,17 @@ const currentPage = Astro.request.url.pathname;
         top: 0;
         padding: 0;
       }
-      #grid-left {
+      #grid-left,
+      #grid-right {
+        height: calc(100vh - 200px);
         max-height: 100vh;
         position: sticky;
         top: 24px;
         display: none;
+        flex-direction: column;
+        // Account for focus rings
+        padding: 8px;
+        margin-left: -8px;
       }
       #grid-main {
         padding: var(--doc-padding) var(--gutter);
@@ -71,6 +78,7 @@ const currentPage = Astro.request.url.pathname;
         height: 100%;
         width: 100%;
       }
+
       @media (min-width: 992px) {
         #article {
           padding: var(--doc-padding) 0;
@@ -79,13 +87,7 @@ const currentPage = Astro.request.url.pathname;
           grid-template-columns: 18rem minmax(0, 1fr);
         }
         #grid-left {
-          display: block;
           display: flex;
-          flex-direction: column;
-          height: calc(100vh - 200px);
-          // Account for focus ring
-          padding: 8px;
-          margin-left: -8px;
         }
         .mobile-nav {
           display: none;
@@ -95,6 +97,16 @@ const currentPage = Astro.request.url.pathname;
       @media (min-width: 1200px) {
         #article {
           grid-template-columns: 22rem minmax(0, 1fr);
+        }
+      }
+
+      @media (min-width: 1300px) {
+        #article {
+          grid-template-columns: 18rem minmax(0, 1fr) 18rem;
+        }
+        #grid-right {
+          grid-column: 3;
+          display: flex;
         }
       }
     </style>
@@ -113,6 +125,9 @@ const currentPage = Astro.request.url.pathname;
         <PageContent id="grid-main" content={content}>
           <slot />
         </PageContent>
+        <div id="grid-right">
+          <RightSidebar content={content}/>
+        </div>
       </div>
     </main>
   </body>

--- a/src/pages/[locale]/[slug].astro
+++ b/src/pages/[locale]/[slug].astro
@@ -109,6 +109,16 @@ const {
 
 const isConfigRefPage = !redirect && page.canonicalSlug === 'config';
 
+if (isConfigRefPage) {
+  const [options] = Astro.fetchContent('../../data/config-reference.md');
+  // Default locale options, for use as fallback if localization is not available
+  const fallbackOptions = options[DEFAULT_LOCALE].options;
+  // config options for locale
+  const configOptions = options[locale] ? options[locale].options : fallbackOptions
+  const optionHeaders = configOptions.map(option => ({depth: 2, slug: option.name, text: option.name}))
+  page.content.headers = optionHeaders;
+}
+
 ---
 
 {redirect 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -38,6 +38,12 @@
   }
 }
 
+@media (min-width: 1400px) {
+  :root {
+    --max-width: 1370px;
+  }
+}
+
 body {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This adds a table of contents for the current page to the right side of the page.  It doesn't indicate the active section, partly because that's a bit buggy and hard to do well and I wanted to keep the JS to a minimum.  It only shows the second-level headlines on the page.

![image](https://user-images.githubusercontent.com/4616705/144510265-2a4d5e80-4282-47ef-b50d-d9dac98ecfe6.png)
