### PR TITLE
Add Guides index

### DIFF
--- a/src/data/docs/en/cli.md
+++ b/src/data/docs/en/cli.md
@@ -1,6 +1,0 @@
----
-title: Get Status With CLI
-slug: cli
-summary: cli
----
-# Get Status With CLI

--- a/src/data/docs/en/guides.md
+++ b/src/data/docs/en/guides.md
@@ -1,6 +1,15 @@
 ---
 title: Guides
 slug: guides
-summary: Here is where you will find how-to guides for various nebula topics.
+summary: A collection of how-to guides that explain how to use various capabilites of the Nebula overlay networking tool.
 ---
-Here are some how-to guides.
+
+# Nebula Guides
+
+Here's where you'll find a list of how-to guides for Nebula. These guides provide step-by-step instructions and explain how to use various capabilities and features of Nebula.
+
+## Index
+
+[Quick Start](quick-start) - This guide explains the core components of Nebula and provides instructions for how to download, configure, and run an overlay network.
+
+[Extend network access beyond overlay hosts](unsafe_routes) - Interested in using Nebula to create a site-to-site VPN? This guide explains how to use Nebula's `unsafe_routes` feature to route traffic _through_ Nebula hosts and remotely connect to devices like printers.

--- a/src/data/docs/en/guides.md
+++ b/src/data/docs/en/guides.md
@@ -13,3 +13,11 @@ Here's where you'll find a list of how-to guides for Nebula. These guides provid
 [Quick Start](quick-start) - This guide explains the core components of Nebula and provides instructions for how to download, configure, and run an overlay network.
 
 [Extend network access beyond overlay hosts](unsafe_routes) - Interested in using Nebula to create a site-to-site VPN? This guide explains how to use Nebula's `unsafe_routes` feature to route traffic _through_ Nebula hosts and remotely connect to devices like printers.
+
+## How to contribute
+
+Found a typo? Have a question? Wish-list? We'd love to hear from you!
+
+Check out [DefinedNet / nebula-docs on GitHub](https://github.com/DefinedNet/nebula-docs) to open an issue or submit a pull request with your suggestions.
+
+All of the Nebula Project pages on this website are pulled in from the `nebula-docs` repo.

--- a/src/data/docs/en/logs.md
+++ b/src/data/docs/en/logs.md
@@ -1,6 +1,0 @@
----
-title: Understanding Nebula Logs
-slug: logs
-summary: logs
----
-#Understanding Nebula Logs

--- a/src/data/docs/en/run-as-service.md
+++ b/src/data/docs/en/run-as-service.md
@@ -1,6 +1,0 @@
----
-title: Run Nebula Automatically
-slug: run-as-service
-summary: Run nebula
----
-# Run Nebula Automatically

--- a/src/data/settings/sidebar.json
+++ b/src/data/settings/sidebar.json
@@ -10,12 +10,6 @@
           "page": "quick-start"
         },
         {
-          "page": "run-as-service"
-        },
-        {
-          "page": "cli"
-        },
-        {
           "page": "unsafe_routes"
         }
       ]


### PR DESCRIPTION
This PR adds content to the `/guides` page, which provides more context to the purpose of each guide.

Guide titles will still be listed on the left hand side for all `/nebula/*`pages.

I've also deleted the stub files for unfinished guides so that we can publish what is currently completed from this repo.