### PR TITLE
Move pages inside `/nebula` route

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,29 @@ Status: Currently work-in-progress and not yet published, but the content matche
 
 All commands are run from the root of the project, from a terminal:
 
-| Command          | Action                                       |
-|:-----------------|:---------------------------------------------|
-| `npm install`    | Installs dependencies                        |
-| `npm start`      | Starts local dev server at `localhost:3000`  |
-
+| Command       | Action                                      |
+| :------------ | :------------------------------------------ |
+| `npm install` | Installs dependencies                       |
+| `npm start`   | Starts local dev server at `localhost:3000` |
 
 ## CMS
 
-The content for this site is managed by Netlify CMS, a git-based content management system.  To add new content, visit `localhost:3000/admin` after starting the dev server locally.  When you run `npm start`, a proxy server that does not attempt to authenticate with GitHub will also be started, allowing changes to be made to the repo on your filesystem, which should then be pushed up and submitted as a pull request.
+The content for this site is managed by Netlify CMS, a git-based content management system. To add new content, visit `localhost:3000/admin` after starting the dev server locally. When you run `npm start`, a proxy server that does not attempt to authenticate with GitHub will also be started, allowing changes to be made to the repo on your filesystem, which should then be pushed up and submitted as a pull request.
 
 If you prefer working in your editor, we suggest creating new files through the cms so that the proper frontmatter is created, and then you're free to edit files directly on disk.
 
 ## Internationalization (i18n)
 
-To add a non-English translation of the docs, open the CMS and add a new locale in Settings -> Locales.  After that is added, you'll be able to edit each Page and change the locale at the top of the right hand side ("Writing in EN").
+To add a non-English translation of the docs, open the CMS and add a new locale in Settings -> Locales. After that is added, you'll be able to edit each Page and change the locale at the top of the right hand side ("Writing in EN").
+
+## URI formatting
+
+⚠️ Always use absolute paths and trailing slashes when linking to other pages in this repo.
+
+All internal page links should begin with `/nebula/`.
+
+    e.g. Check out the [Nebula Getting Started Guide](/nebula/quick-start/).
+         https://www.defined.net/nebula/quick-start/
 
 ## Architecture
 
@@ -32,7 +40,7 @@ The other components, styles, and layout in `/src` are very similar to what is p
 
 ### Config Reference
 
-The configuration reference is constructed differently from the other pages.  It is composed of the `config.md` file which provides the top of the page, and `config-reference.md` which contains the actual configuration option documentation.  This separation was done to support internationalization.
+The configuration reference is constructed differently from the other pages. It is composed of the `config.md` file which provides the top of the page, and `config-reference.md` which contains the actual configuration option documentation. This separation was done to support internationalization.
 
 ## Known Issues
 
@@ -44,4 +52,4 @@ When viewing the localhost site for the first time, you may see the following di
 >
 > The current page should have reloaded by now
 
-Refresh your browser to work around this warning. The correctly rendered page will display after one or two refreshes.  Upstream issue: https://github.com/withastro/astro/issues/1803
+Refresh your browser to work around this warning. The correctly rendered page will display after one or two refreshes. Upstream issue: https://github.com/withastro/astro/issues/1803

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the documentation for the [nebula open source project](https://github.com/slackhq/nebula).
 
-Status: Currently work-in-progress and not yet published, but the content matches https://www.defined.net/nebula/.
+Status: Currently a work-in-progress. Content matches what is published at https://www.defined.net/nebula/.
 
 ## Commands Cheatsheet
 
@@ -23,18 +23,9 @@ If you prefer working in your editor, we suggest creating new files through the 
 
 To add a non-English translation of the docs, open the CMS and add a new locale in Settings -> Locales. After that is added, you'll be able to edit each Page and change the locale at the top of the right hand side ("Writing in EN").
 
-## URI formatting
-
-⚠️ Always use absolute paths and trailing slashes when linking to other pages in this repo.
-
-All internal page links should begin with `/nebula/`.
-
-    e.g. Check out the [Nebula Getting Started Guide](/nebula/quick-start/).
-         https://www.defined.net/nebula/quick-start/
-
 ## Architecture
 
-This project is not published directly to the web, but the files in `/src/data` are pulled in to the build process of [defined.net/nebula](https://www.defined.net/nebula/).
+This project is not published directly to the web, but the files in `/src/data` are pulled in to the build process of [www.defined.net/nebula/](https://www.defined.net/nebula/).
 
 The other components, styles, and layout in `/src` are very similar to what is published under `/nebula/` on the Defined Networking website. This repo contains a few additional files to make it easier for contributors to run a standalone Nebula Docs server and to preview rendered changes locally before submitting a pull request.
 

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -3,7 +3,7 @@ import { getLanguageFromURL, getLanguageFromFilename, getSlugFromFilename, KNOWN
 import SkipToContent from './SkipToContent.astro';
 import LanguageSelect from './LanguageSelect.tsx';
 
-const currentPath = Astro.request.url.pathname;
+const currentPath = Astro.request.canonicalURL.pathname;
 const lang = currentPath && getLanguageFromURL(currentPath);
 const {canonicalSlug} = Astro.props;
 ---

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -2,7 +2,7 @@
 import {getSections} from '../../get-page-links'
 import NavLink from '../Nav/NavLink.astro';
 
-const {currentPage} = Astro.props;
+const currentPage = Astro.request.canonicalURL.pathname;
 const allPages = Astro.fetchContent('../../data/**/*.md');
 const sections = getSections({currentPage, allPages})
 

--- a/src/components/MobileNav.astro
+++ b/src/components/MobileNav.astro
@@ -1,7 +1,7 @@
 ---
 import {getPageLinks} from '../get-page-links'
 const allPages = Astro.fetchContent('../data/**/*.md');
-const currentPage = Astro.request.url.pathname.replace(/\/$/, '');
+const currentPage = Astro.request.canonicalURL.pathname;
 const pages = getPageLinks({currentPage, allPages});
 
 const currentPageTitle = pages.find(p => p.href === currentPage)?.title

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,4 +2,5 @@ export const SITE = {
   title: 'Nebula Project',
   description: 'Documentation for the nebula open source project.',
   defaultLanguage: 'en_US',
+  root: '/nebula',
 };

--- a/src/data/docs/en/guides.md
+++ b/src/data/docs/en/guides.md
@@ -10,14 +10,18 @@ Here's where you'll find a list of how-to guides for Nebula. These guides provid
 
 ## Index
 
-[Quick Start](/nebula/quick-start) - This guide explains the core components of Nebula and provides instructions for how to download, configure, and run an overlay network.
+[Quick Start](/nebula/quick-start)  
+This guide explains the core components of Nebula and provides instructions for how to download, configure, and run an overlay network.
 
-[Extend network access beyond overlay hosts](/nebula/unsafe_routes) - Interested in using Nebula to create a site-to-site VPN? This guide explains how to use Nebula's `unsafe_routes` feature to route traffic _through_ Nebula hosts and remotely connect to devices like printers.
+[Extend network access beyond overlay hosts](/nebula/unsafe_routes)  
+Interested in using Nebula to create a site-to-site VPN? This guide explains how to use Nebula's `unsafe_routes` feature to route traffic _through_ Nebula hosts and remotely connect to devices like printers.
 
 ## How to contribute
 
 Found a typo? Have a question? Wish-list? We'd love to hear from you!
 
-Check out [DefinedNet / nebula-docs on GitHub](https://github.com/DefinedNet/nebula-docs) to open an issue or submit a pull request with your suggestions.
+All of the Nebula Project pages on this website are pulled in from the `DefinedNet/nebula-docs` repo on GitHub.
 
-All of the Nebula Project pages on this website are pulled in from the `nebula-docs` repo.
+[Nebula Documentation on GitHub](https://github.com/DefinedNet/nebula-docs)
+
+Open an issue or submit a pull request with your suggestions.

--- a/src/data/docs/en/guides.md
+++ b/src/data/docs/en/guides.md
@@ -10,10 +10,10 @@ Here's where you'll find a list of how-to guides for Nebula. These guides provid
 
 ## Index
 
-[Quick Start](/nebula/quick-start)  
+[Quick Start](/nebula/quick-start/)  
 This guide explains the core components of Nebula and provides instructions for how to download, configure, and run an overlay network.
 
-[Extend network access beyond overlay hosts](/nebula/unsafe_routes)  
+[Extend network access beyond overlay hosts](/nebula/unsafe_routes/)  
 Interested in using Nebula to create a site-to-site VPN? This guide explains how to use Nebula's `unsafe_routes` feature to route traffic _through_ Nebula hosts and remotely connect to devices like printers.
 
 ## How to contribute

--- a/src/data/docs/en/overview.md
+++ b/src/data/docs/en/overview.md
@@ -41,7 +41,7 @@ Nebula is written in Go and is designed for portability.
 
 ## Getting Started
 
-[How to create your first overlay network](quick-start) is a step-by-step guide that explains how to deploy Nebula. It's a great place to get started and learn how to connect a few hosts.
+[How to create your first overlay network](/nebula/quick-start) is a step-by-step guide that explains how to deploy Nebula. It's a great place to get started and learn how to connect a few hosts.
 
 ### Overview presentation
 

--- a/src/data/docs/en/overview.md
+++ b/src/data/docs/en/overview.md
@@ -10,7 +10,7 @@ summary: Nebula is an open-source overlay networking tool designed
 
 Nebula is an overlay networking tool designed to be fast, secure, and scalable. Connect any number of hosts with on-demand, encrypted tunnels that work across any IP networks and without opening firewall ports.
 
-[Download Nebula on GitHub [slackhq/nebula]](https://github.com/slackhq/nebula)
+[Download Nebula on GitHub](https://github.com/slackhq/nebula)
 
 ## Core features
 
@@ -41,7 +41,9 @@ Nebula is written in Go and is designed for portability.
 
 ## Getting Started
 
-[How to create your first overlay network](/nebula/quick-start) is a step-by-step guide that explains how to deploy Nebula. It's a great place to get started and learn how to connect a few hosts.
+_How to create your first overlay network_ is a step-by-step guide that explains how to deploy Nebula. It's a great place to get started and learn how to connect a few hosts.
+
+[Nebula Quick Start guide](/nebula/quick-start)
 
 ### Overview presentation
 

--- a/src/data/docs/en/overview.md
+++ b/src/data/docs/en/overview.md
@@ -43,7 +43,7 @@ Nebula is written in Go and is designed for portability.
 
 _How to create your first overlay network_ is a step-by-step guide that explains how to deploy Nebula. It's a great place to get started and learn how to connect a few hosts.
 
-[Nebula Quick Start guide](/nebula/quick-start)
+[Nebula Quick Start guide](/nebula/quick-start/)
 
 ### Overview presentation
 

--- a/src/data/docs/en/unsafe_routes.md
+++ b/src/data/docs/en/unsafe_routes.md
@@ -14,7 +14,7 @@ This is especially useful for accessing hosts that cannot be modified to run Neb
 
 ## Prerequisites
 
-_Read the [Quick Start](/nebula/quick-start) guide to learn how to create your first overlay network._
+_Read the [Quick Start](/nebula/quick-start/) guide to learn how to create your first overlay network._
 
 You'll need the following to complete this guide.
 

--- a/src/get-page-links.ts
+++ b/src/get-page-links.ts
@@ -36,6 +36,5 @@ function buildPageObj(slug: string, langCode: string, allPages: any) {
   if (!page) {
     page = allPages.find(p => getSlugFromFilename(p.file.pathname) === slug && getLanguageFromFilename(p.file.pathname) === DEFAULT_LOCALE);
   }
-
-  return {title: page.title, href: `${SITE.root}/${langCode}/${page.slug}` }
+  return {title: page.title, href: `${SITE.root}/${langCode}/${page.slug}/` }
 }

--- a/src/get-page-links.ts
+++ b/src/get-page-links.ts
@@ -1,5 +1,6 @@
 import sidebarConfig from './data/settings/sidebar.json';
 import {getLanguageFromURL, getSlugFromFilename, getLanguageFromFilename, DEFAULT_LOCALE} from './languages';
+import {SITE} from './config';
 
 export function getSections({currentPage, allPages}) {
   const langCode = getLanguageFromURL(currentPage);
@@ -36,5 +37,5 @@ function buildPageObj(slug: string, langCode: string, allPages: any) {
     page = allPages.find(p => getSlugFromFilename(p.file.pathname) === slug && getLanguageFromFilename(p.file.pathname) === DEFAULT_LOCALE);
   }
 
-  return {title: page.title, href: `/${langCode}/${page.slug}` }
+  return {title: page.title, href: `${SITE.root}/${langCode}/${page.slug}` }
 }

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -8,7 +8,6 @@ import MobileNav from '../components/MobileNav.astro'
 import * as CONFIG from "../config";
 
 const { content = {} } = Astro.props;
-const currentPage = Astro.request.url.pathname;
 ---
 
 <html dir={content.dir ?? 'ltr'} lang={content.lang ?? 'en-us'} class="initial">
@@ -117,7 +116,7 @@ const currentPage = Astro.request.url.pathname;
     <main>
       <div id='article'>
         <aside id="grid-left" class="grid-sidebar" title="Site Navigation">
-          <LeftSidebar currentPage={currentPage} />
+          <LeftSidebar />
         </aside>
         <div class="mobile-nav">
           <MobileNav />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,3 +1,3 @@
 <script>
-  window.location.pathname = `/nebula/en/overview`;
+  window.location.pathname = `/nebula/en/overview/`;
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,3 @@
 <script>
-  // Redirect your homepage to the first page of documentation.
-  // If you have a landing page, remove this script and add it here!
-  window.location.pathname = `/en/overview`;
+  window.location.pathname = `/nebula/en/overview`;
 </script>

--- a/src/pages/nebula/[locale]/[slug].astro
+++ b/src/pages/nebula/[locale]/[slug].astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '../../layouts/MainLayout.astro';
-import ConfigReference from '../../components/ConfigReference.astro';
-import Redirect from '../../components/Redirect.astro';
-import {getLanguageFromFilename, getSlugFromFilename, DEFAULT_LOCALE, KNOWN_LANGUAGE_CODES} from '../../languages';
+import Layout from '../../../layouts/MainLayout.astro';
+import ConfigReference from '../../../components/ConfigReference.astro';
+import Redirect from '../../../components/Redirect.astro';
+import {getLanguageFromFilename, getSlugFromFilename, DEFAULT_LOCALE, KNOWN_LANGUAGE_CODES} from '../../../languages';
 
 export async function getStaticPaths() {
   /**
@@ -68,7 +68,7 @@ export async function getStaticPaths() {
       .flat();
   }
 
-  const allPages = Astro.fetchContent('../../data/docs/**/*.md');
+  const allPages = Astro.fetchContent('../../../data/docs/**/*.md');
 
   const redirects = getRedirects(allPages);
   const fallbacks = getFallbacks(allPages);

--- a/src/pages/nebula/[slug].astro
+++ b/src/pages/nebula/[slug].astro
@@ -1,0 +1,49 @@
+---
+import Layout from '../../layouts/MainLayout.astro';
+import ConfigReference from '../../components/ConfigReference.astro';
+import {DEFAULT_LOCALE} from '../../languages';
+
+/**
+ * This file is used for urls without a locale, which means they are for the default language.
+ */
+
+export async function getStaticPaths() {
+  const allPages = Astro.fetchContent('../../data/docs/en/**/*.md');
+
+  const paths = allPages.map(({ astro, url, file, ...page }) => {
+    return {
+      params: {
+        slug: page.slug
+      },
+      props: {
+        page: {
+          ...page,
+          html: astro.html
+        }
+      }
+    }
+  })
+
+  // Filter out any paths with an undefined locale or slug.
+  return paths.filter(({ params }) => !!params.slug);
+}
+
+const { 
+  /** Contains the frontmatter from the page data, including title, summary, etc. */
+  page, 
+} = Astro.props
+
+const isConfigRefPage = page.slug === 'config';
+
+if (isConfigRefPage) {
+  const [options] = Astro.fetchContent('../../data/config-reference.md');
+  const configOptions = options[DEFAULT_LOCALE].options;
+  const optionHeaders = configOptions.map(option => ({depth: 2, slug: option.name, text: option.name}))
+  page.content.headers = optionHeaders;
+}
+---
+
+<Layout content={page}>
+    {page.html}
+    {isConfigRefPage && <ConfigReference locale={DEFAULT_LOCALE}/>}
+</Layout>


### PR DESCRIPTION
This addresses an issue with internal links between docs pages.  We host these nebula docs at `www.defined.net/nebula`, whereas we were serving them in this repo directly out of the root.  This PR unifies the structure, so that we can use root-relative links between the pages, and they will work here when building/previewing the docs in this repo.  

Also, since we currently are not using localized pages on defined.net, this adds the ability to use urls like `/nebula/overview` directly, and it will work in both defined.net as well as in this repo.  