### PR TITLE
Document `stats` config group

### DIFF
--- a/docs/config/stats.mdx
+++ b/docs/config/stats.mdx
@@ -30,9 +30,12 @@ stats:
 
 ## stats.type
 
-Choose your stats provider. Options are `graphite` and `prometheus`. This will determine other available options.
+Choose your stats provider. Options are `graphite` and `prometheus`. If unset, nebula will not report statistics to a provider.
+This will determine other available options.
 
 ## stats.interval
+
+<Pill className="mb-24">Required</Pill>
 
 Duration.
 
@@ -54,21 +57,29 @@ Config options if `stats.type` is chosen to be `graphite`
 
 ### stats.prefix
 
-`nebula` by default
+<Pill className="mb-24">
+  Default: <span data-no-transform>nebula</span>
+</Pill>
 
 ### stats.protocol
 
-<Pill className="mb-24">Default: tcp</Pill>
+<Pill className="mb-24">
+  Default: <span data-no-transform>tcp</span>
+</Pill>
 
 Choose which protocol is used for passing stats to Graphite. The options are `tcp` and `udp`.
 
 ### stats.host
+
+<Pill className="mb-24">Required</Pill>
 
 ## Prometheus options
 
 Config options if `stats.type` is chosen to be `prometheus`
 
 ### stats.listen
+
+<Pill className="mb-24">Required</Pill>
 
 TCP address of `0.0.0.0:8080` or `:8080` or `192.168.14.12:1234`, for instance.
 

--- a/docs/config/stats.mdx
+++ b/docs/config/stats.mdx
@@ -60,13 +60,13 @@ Config options if `stats.type` is chosen to be `graphite`
 ### stats.prefix
 
 <Pill className="mb-24">
-  Default: <span data-no-transform>nebula</span>
+  Default: <span className="no-transform">nebula</span>
 </Pill>
 
 ### stats.protocol
 
 <Pill className="mb-24">
-  Default: <span data-no-transform>tcp</span>
+  Default: <span className="no-transform">tcp</span>
 </Pill>
 
 Choose which protocol is used for passing stats to Graphite. The options are `tcp` and `udp`.

--- a/docs/config/stats.mdx
+++ b/docs/config/stats.mdx
@@ -6,7 +6,8 @@ import { Pill } from '@components/Pill/Pill';
 
 # stats
 
-Nebula sorts outputting stats for [Graphite](https://graphiteapp.org/) or [Prometheus](https://prometheus.io/). Options passed / required will depend on `stats.type`.
+Nebula sorts outputting stats for [Graphite](https://graphiteapp.org/) or [Prometheus](https://prometheus.io/). Options
+passed / required will depend on `stats.type`.
 
 ```yml
 stats:
@@ -30,8 +31,8 @@ stats:
 
 ## stats.type
 
-Choose your stats provider. Options are `graphite` and `prometheus`. If unset, nebula will not report statistics to a provider.
-This will determine other available options.
+Choose your stats provider. Options are `graphite` and `prometheus`. If unset, nebula will not report statistics to a
+provider. This will determine other available options.
 
 ## stats.interval
 
@@ -43,7 +44,8 @@ Duration.
 
 <Pill className="mb-24">Default: False</Pill>
 
-Enables counter metrics for meta packets, e.g.: `messages.tx.handshake`. NOTE: `message.{tx,rx}.recv_error` is always emitted.
+Enables counter metrics for meta packets, e.g.: `messages.tx.handshake`. NOTE: `message.{tx,rx}.recv_error` is always
+emitted.
 
 ## stats.lighthouse_metrics
 

--- a/docs/config/stats.mdx
+++ b/docs/config/stats.mdx
@@ -30,7 +30,23 @@ stats:
 
 ## stats.type
 
-options are `graphite` and `prometheus`. This will determine other available options.
+Choose your stats provider. Options are `graphite` and `prometheus`. This will determine other available options.
+
+## stats.interval
+
+Duration.
+
+## stats.message_metrics
+
+<Pill className="mb-24">Default: False</Pill>
+
+Enables counter metrics for meta packets, e.g.: `messages.tx.handshake`. NOTE: `message.{tx,rx}.recv_error` is always emitted.
+
+## stats.lighthouse_metrics
+
+<Pill className="mb-24">Default: False</Pill>
+
+Enables detailed counter metrics for lighthouse packets, e.g.: `lighthouse.rx.HostQuery`.
 
 ## Graphite options
 
@@ -42,11 +58,11 @@ Config options if `stats.type` is chosen to be `graphite`
 
 ### stats.protocol
 
-tcp|udp, but must only be TCP lol
+<Pill className="mb-24">Default: tcp</Pill>
+
+Choose which protocol is used for passing stats to Graphite. The options are `tcp` and `udp`.
 
 ### stats.host
-
-### stats.interval
 
 ## Prometheus options
 
@@ -65,19 +81,3 @@ Path to serve up stats at, for example `/my-stats`
 ### stats.namespace
 
 ### stats.subsystem
-
-### stats.interval
-
-Duration.
-
-## stats.message_metrics
-
-<Pill className="mb-24">Default: False</Pill>
-
-Enables counter metrics for meta packets, e.g.: `messages.tx.handshake`. NOTE: `message.{tx,rx}.recv_error` is always emitted.
-
-## stats.lighthouse_metrics
-
-<Pill className="mb-24">Default: False</Pill>
-
-Enables detailed counter metrics for lighthouse packets, e.g.: `lighthouse.rx.HostQuery`.

--- a/docs/config/stats.mdx
+++ b/docs/config/stats.mdx
@@ -1,0 +1,83 @@
+---
+sidebar_position: 14
+---
+
+import { Pill } from '@components/Pill/Pill';
+
+# stats
+
+Nebula sorts outputting stats for [Graphite](https://graphiteapp.org/) or [Prometheus](https://prometheus.io/). Options passed / required will depend on `stats.type`.
+
+```yml
+stats:
+  type: graphite
+  prefix: nebula
+  protocol: tcp
+  host: 127.0.0.1:9999
+  interval: 10s
+
+  type: prometheus
+  listen: 127.0.0.1:8080
+  path: /metrics
+  namespace: prometheusns
+  subsystem: nebula
+  interval: 10s
+
+  message_metrics: false
+
+  lighthouse_metrics: false
+```
+
+## stats.type
+
+options are `graphite` and `prometheus`. This will determine other available options.
+
+## Graphite options
+
+Config options if `stats.type` is chosen to be `graphite`
+
+### stats.prefix
+
+`nebula` by default
+
+### stats.protocol
+
+tcp|udp, but must only be TCP lol
+
+### stats.host
+
+### stats.interval
+
+## Prometheus options
+
+Config options if `stats.type` is chosen to be `prometheus`
+
+### stats.listen
+
+TCP address of `0.0.0.0:8080` or `:8080` or `192.168.14.12:1234`, for instance.
+
+### stats.path
+
+<Pill className="mb-24">Required</Pill>
+
+Path to serve up stats at, for example `/my-stats`
+
+### stats.namespace
+
+### stats.subsystem
+
+### stats.interval
+
+Duration.
+
+## stats.message_metrics
+
+<Pill className="mb-24">Default: False</Pill>
+
+Enables counter metrics for meta packets, e.g.: `messages.tx.handshake`. NOTE: `message.{tx,rx}.recv_error` is always emitted.
+
+## stats.lighthouse_metrics
+
+<Pill className="mb-24">Default: False</Pill>
+
+Enables detailed counter metrics for lighthouse packets, e.g.: `lighthouse.rx.HostQuery`.

--- a/src/components/Pill/Pill.module.css
+++ b/src/components/Pill/Pill.module.css
@@ -7,6 +7,10 @@
   border-radius: 10rem;
   background-color: var(--ifm-color-emphasis-200);
   padding: 4px 8px;
+
+  & :global([data-no-transform]) {
+    text-transform: none;
+  }
 }
 
 .Pill___info {

--- a/src/components/Pill/Pill.module.css
+++ b/src/components/Pill/Pill.module.css
@@ -8,7 +8,7 @@
   background-color: var(--ifm-color-emphasis-200);
   padding: 4px 8px;
 
-  & :global([data-no-transform]) {
+  & :global(.no-transform) {
     text-transform: none;
   }
 }


### PR DESCRIPTION
Broke this out from #42 since it needs a bit more work and information added.

This will add docs for the `stats` config group