### PR TITLE
Increase Pill size for better readability

### DIFF
--- a/src/components/Pill/Pill.module.css
+++ b/src/components/Pill/Pill.module.css
@@ -1,7 +1,7 @@
 .Pill {
   display: inline-block;
   text-transform: uppercase;
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 600;
   line-height: 1;
   border-radius: 10rem;


### PR DESCRIPTION
Currently we have a font-size of `10px` for the Pill component, this sets a font-size of `12px` instead