### PR TITLE
Update local_allow_ranges note for IPv6 default requirement

### DIFF
--- a/docs/config/lighthouse.mdx
+++ b/docs/config/lighthouse.mdx
@@ -93,7 +93,8 @@ referenced by their **nebula IP**, not by the IPs of their physical network inte
 remote_allow_list allows you to control ip ranges that this node will consider when handshaking to another node. By
 default, any remote IPs are allowed. You can provide CIDRs here with `true` to allow and `false` to deny. The most
 specific CIDR rule applies to each remote. If all rules are "allow", the default will be "deny", and vice-versa. If both
-"allow" and "deny" rules are present, then you MUST set a rule for "0.0.0.0/0" as the default.
+"allow" and "deny" rules are present, then you MUST set a rule for "0.0.0.0/0" as the default. Similarly if both "allow"
+and "deny" IPv6 rules are present, then you MUST set a rule for "::/0" as the default.
 
 ## lighthouse.local_allow_list
 


### PR DESCRIPTION
This is the same note I posted to nebula as a PR here: https://github.com/slackhq/nebula/pull/742