### PR TITLE
Add example config for setting up DNS on the lighthouse

### DIFF
--- a/docs/config/lighthouse.mdx
+++ b/docs/config/lighthouse.mdx
@@ -78,10 +78,11 @@ To allow hosts to make queries against the DNS server over the Nebula network, d
 The below example config will allow any host on the network to query the lighthouse for DNS
 
 ```yml
-inbound:
-  - port: 53
-    proto: udp
-    group: any
+firewall:
+  inbound:
+    - port: 53
+      proto: udp
+      group: any
 ```
 
 :::

--- a/docs/config/lighthouse.mdx
+++ b/docs/config/lighthouse.mdx
@@ -75,6 +75,15 @@ $ dig +short @192.168.100.1 192.168.100.5 TXT
 To allow hosts to make queries against the DNS server over the Nebula network, don't forget to allow access in the
 [firewall](/config/firewall).
 
+The below example config will allow any host on the network to query the lighthouse for DNS
+
+```yml
+inbound:
+  - port: 53
+    proto: udp
+    group: any
+```
+
 :::
 
 ## lighthouse.dns


### PR DESCRIPTION
This adds an example firewall config for allowing any host on the network to query the lighthouse for DNS info