### PR TITLE
Fix unsafe_routes url

### DIFF
--- a/docs/guides/unsafe_routes/index.mdx
+++ b/docs/guides/unsafe_routes/index.mdx
@@ -1,6 +1,5 @@
 ---
 title: Extend network access beyond overlay hosts
-slug: unsafe_routes
 summary:
   This guide explains how to configure Nebula to route traffic destined for a specific subnet through a specific overlay
   network host, which is useful for accessing hosts that cannot be modified to run Nebula.


### PR DESCRIPTION
It was duplicated (guides/unsafe_routes/unsafe_routes).