### PR TITLE
Use trailing slashes in links

### DIFF
--- a/docs/config/lighthouse.mdx
+++ b/docs/config/lighthouse.mdx
@@ -73,7 +73,7 @@ $ dig +short @192.168.100.1 192.168.100.5 TXT
 :::note
 
 To allow hosts to make queries against the DNS server over the Nebula network, don't forget to allow access in the
-[firewall](/docs/config/firewall).
+[firewall](/docs/config/firewall/).
 
 The below example config will allow any host on the network to query the lighthouse for DNS
 

--- a/docs/config/local-range.mdx
+++ b/docs/config/local-range.mdx
@@ -6,7 +6,7 @@ sidebar_position: 14
 
 :::caution
 
-`local_range` has been deprecated in favor of [`preferred_ranges`](/docs/config/preferred-ranges)
+`local_range` has been deprecated in favor of [`preferred_ranges`](/docs/config/preferred-ranges/)
 
 :::
 

--- a/docs/config/preferred-ranges.mdx
+++ b/docs/config/preferred-ranges.mdx
@@ -27,7 +27,7 @@ Ordered from highest to lowest priority:
 1. IP address is ipv6
 1. IP address is public ipv4
 1. IP address is private ipv4
-1. Route is via a [relay](/docs/config/relay) (experimental)
+1. Route is via a [relay](/docs/config/relay/) (experimental)
 
 </figure>
 
@@ -45,7 +45,7 @@ an ipv6 range, they will be sorted as shown above. So, the ipv6 would be given p
 
 :::info
 
-The previous option [`local_range`](/docs/config/local-range) only allowed definition of a single range and has been
+The previous option [`local_range`](/docs/config/local-range/) only allowed definition of a single range and has been
 deprecated and replaced by `preferred_ranges`.
 
 :::

--- a/docusaurus.config.cjs
+++ b/docusaurus.config.cjs
@@ -116,7 +116,7 @@ const config = {
               },
               {
                 label: 'Docs',
-                href: 'https://docs.defined.net/dn',
+                href: 'https://docs.defined.net',
               },
               {
                 label: 'Twitter',

--- a/docusaurus.config.cjs
+++ b/docusaurus.config.cjs
@@ -13,6 +13,7 @@ const config = {
   url: 'https://docs.defined.net',
   // For deploy previews, don't set a baseUrl
   baseUrl: '/',
+  trailingSlash: true,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
@@ -62,7 +63,7 @@ const config = {
         title: 'Nebula Docs',
         logo: {
           alt: 'Defined Networking logo',
-          href: '/docs',
+          href: '/docs/',
           src: 'img/mark.svg',
           srcDark: 'img/mark-dark.svg',
         },
@@ -81,11 +82,11 @@ const config = {
             items: [
               {
                 label: 'Guides',
-                to: '/docs/guides',
+                to: '/docs/guides/',
               },
               {
                 label: 'Config Reference',
-                to: '/docs/config',
+                to: '/docs/config/',
               },
             ],
           },


### PR DESCRIPTION
Adds trailing slashes to internal links, and sets the `trailingSlash` option to `true`.  See https://github.com/facebook/docusaurus/pull/4908 for some background on that option.

Also fixes a link to the dn docs.