### PR TITLE
Various edits and tweaks for clarity

### DIFF
--- a/docs/config/cipher.mdx
+++ b/docs/config/cipher.mdx
@@ -6,13 +6,16 @@ sidebar_position: 6
 
 :::danger
 
-This value must be identical on ALL NODES/LIGHTHOUSES. Nebula does not support use of different ciphers simultaneously!
+This value must be identical on ALL nodes and lighthouses. Nebula does not support the use of different ciphers
+simultaneously!
 
 :::
 
-`cipher` allows you to choose between the available ciphers for your network. The default is `aes`, and the available
-options are `chachapoly` or `aes`.
+`cipher` allows you to choose between the available ciphers for your network. You may choose `chachapoly` to use the
+ChaCha20-Poly1305 cipher or `aes` for AES256-GCM.
+
+Because most devices have hardware support for the AES instruction set (e.g. AES-NI), this is the recommended option.
 
 ```yml
-cipher: chachapoly
+cipher: aes
 ```

--- a/docs/config/relay.mdx
+++ b/docs/config/relay.mdx
@@ -4,9 +4,10 @@ sidebar_position: 8
 
 # relay
 
-:::info
+:::caution
 
-EXPERIMENTAL: relay support for networks that can’t establish direct connections.
+Relay support is new and therefore should be considered experimental. However, relays are a useful tool for solving
+tricky connectivity issues between hosts that otherwise are unable to route packets to each other.
 
 :::
 
@@ -20,14 +21,17 @@ relay:
 
 ## relay.relays
 
-`relays` are a list of Nebula IPs that peers can use to relay packets to the host. IPs in this list must have `am_relay`
-set to `true` in their configs, otherwise they will reject relay requests.
+`relays` are a list of Nebula IPs that peers can use to relay packets to this host. IPs in this list must have
+`am_relay` set to `true` in their configs, otherwise they will reject relay requests.
 
 ```yml
 relays:
   - 192.168.100.1
   - <other Nebula VPN IPs of hosts used as relays to access me>
 ```
+
+This list of relays is reported to the Lighthouse. When other nodes attempt to handshake with this host, the Lighthouse
+will indicate its supported relays in addition to its known IP addresses.
 
 ## relay.am_relay
 

--- a/docs/config/tun.mdx
+++ b/docs/config/tun.mdx
@@ -74,9 +74,10 @@ tun:
 
 ## tun.unsafe_routes
 
-:::danger
+:::caution
 
-The nebula certificate of the `via` node MUST have the `route` defined as a subnet in its certificate.
+The nebula certificate of the `via` node MUST have the `route` defined as a subnet in its certificate or it will refuse
+to route traffic.
 
 :::
 

--- a/docs/guides/sign-certificates-with-public-keys/index.mdx
+++ b/docs/guides/sign-certificates-with-public-keys/index.mdx
@@ -29,7 +29,7 @@ nebula-cert keygen -out-key alice.key -out-pub alice.pub
 
 This will save the private and public keys to `alice.key` and `alice.pub` respectively.
 
-:::danger
+:::caution
 
 The private key, along with certificate you will create below, is what Nebula will use to prove its identity during
 handshakes. Do not share this private key with anyone else! It is recommended that you do not copy the private key to

--- a/docs/guides/sign-certificates-with-public-keys/index.mdx
+++ b/docs/guides/sign-certificates-with-public-keys/index.mdx
@@ -29,7 +29,7 @@ nebula-cert keygen -out-key alice.key -out-pub alice.pub
 
 This will save the private and public keys to `alice.key` and `alice.pub` respectively.
 
-:::note
+:::danger
 
 The private key, along with certificate you will create below, is what Nebula will use to prove its identity during
 handshakes. Do not share this private key with anyone else! It is recommended that you do not copy the private key to

--- a/docs/guides/using-lighthouse-dns/index.mdx
+++ b/docs/guides/using-lighthouse-dns/index.mdx
@@ -2,7 +2,8 @@
 
 :::caution
 
-Lighthouse DNS in nebula is Experimental and not intended to be a robust solution currently.
+Lighthouse DNS in nebula is experimental and should not be considered to be a robust solution. For details, see the
+[limitations](#limitations) listed below.
 
 :::
 
@@ -11,27 +12,15 @@ Nebula comes with built-in DNS server support via Lighthouse hosts.
 Lighthouse DNS can generate DNS records based on dynamic nebula hosts, useful if you are spinning up new nebula hosts on
 demand.
 
-An alternative approach to DNS would be to point public DNS records at private nebula IP addresses. For example, you can
-create a public DNS A record pointing to `10.0.0.23` for your private team wiki. While this does make your internal IP
-address visible to the internet, only users on your nebula network will be able to access it.
+## Prerequisites
 
-To get started, set up a lighthouse and two hosts using our [Quick Start guide](/docs/guides/quick-start/).
-
-You can then use [`lighthouse.serve_dns`](/docs/config/lighthouse#lighthouseserve_dns) and the
-[`lighthouse.dns`](/docs/config/lighthouse#lighthousedns) config settings for your lighthouse config file to enable
-Lighthouse DNS.
-
-:::note
-
-Only Lighthouses should have `lighthouse.serve_dns` enabled, as DNS info is collected when hosts report to the
-lighthouse. Nebula will not honor the option if enabled on a non-lighthouse host.
-
-:::
+This guide assumes you already have a working Lighthouse and at least one other host communicating with it. If you
+haven't setup a Nebula network yet, check out the [Quick Start guide](/docs/guides/quick-start/).
 
 You'll then want to set up the lighthouse as a DNS server for the other two hosts. This can be either the public static
 lighthouse IP or the private nebula IP depending on the Lighthouse's configuration.
 
-## Tutorial
+## Configuration
 
 First, spin up a lighthouse and 2 hosts. Then add
 
@@ -43,12 +32,19 @@ lighthouse:
     port: 53
 ```
 
-to your config for your lighthouse. By setting `lighthouse.dns.host` to `[::]`, nebula will bind to all interfaces,
+to your lighthouses's Nebula config. By setting `lighthouse.dns.host` to `[::]`, nebula will bind to all interfaces
 including both the public and nebula IP. Binding to only the nebula IP, for example `lighthouse.dns.host: 10.0.0.1` will
 ensure the DNS is only accessible to hosts that are allowed to contact the lighthouse via nebula.
 
-Additionally, add a [firewall rule](/docs/config/firewall) in your lighthouse config that enables UDP on port `53` (or
-the port in `lighthouse.dns.port`) for all hosts you want to be able to query DNS on the lighthouse. For example to
+:::note
+
+Only Lighthouses should have `lighthouse.serve_dns` enabled, as DNS info is collected when hosts report to the
+lighthouse. Nebula will not honor the option if enabled on a non-lighthouse host.
+
+:::
+
+Next, add a [firewall rule](/docs/config/firewall) in your lighthouse config that enables UDP on port `53` (or the port
+specified in `lighthouse.dns.port`) for all hosts you want to be able to query DNS on the lighthouse. For example to
 allow any host on the nebula network:
 
 ```yaml
@@ -58,6 +54,8 @@ firewall:
       proto: UDP
       group: any
 ```
+
+## Testing
 
 Then you can run `dig` against it to test! For example, I made a host named `lighthouse` as my lighthouse with nebula IP
 `100.100.0.1` and `alice-laptop` with nebula IP `100.100.0.2` as my host, and I set up my lighthouse with the above
@@ -86,14 +84,28 @@ curl --dns-servers "100.100.0.1" http://alice-laptop:3000
 <div>hello i am a website</div>
 ```
 
-## Name hosts with valid domain names
+## Limitations
 
-Hosts with names conforming to the [DNS RFC](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) will be resolved,
-otherwise the Lighthouse DNS will return an empty response.
+- The built-in DNS server will only respond to queries for known Nebula hosts and will not make upstream queries to a
+  secondary DNS server (e.g. for supporting both internal DNS and public DNS.)
+- A host's hostname is restricted to the name in its certificate.
+- There is no way to register additional hostnames (e.g. additional CNAMEs for a given Nebula host, or additional A
+  records for managing non-Nebula hosts.)
+- Duplicate names in certificates will result in non-stable answers from the DNS server.
+- If the name in the Nebula certificate is not a [valid hostname](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1),
+Lighthouse DNS will return an empty result.
+
+### Hostname Validity
 
 import { ValidateDomainInput } from './ValidateDomainInput';
 
 <ValidateDomainInput />
+
+## Alternatives
+
+An alternative approach to DNS would be to point public DNS records at private nebula IP addresses. For example, you can
+create a public DNS A record pointing to `10.0.0.23` for your private team wiki. While this does make your internal IP
+address visible to the internet, only users on your nebula network will be able to access it.
 
 ## Q&A
 

--- a/docs/guides/using-lighthouse-dns/index.mdx
+++ b/docs/guides/using-lighthouse-dns/index.mdx
@@ -95,7 +95,7 @@ curl --dns-servers "100.100.0.1" http://alice-laptop:3000
 - If the name in the Nebula certificate is not a [valid hostname](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1),
 Lighthouse DNS will return an empty result.
 
-### Hostname Validity
+## Hostname Validity
 
 import { ValidateDomainInput } from './ValidateDomainInput';
 


### PR DESCRIPTION
Went around trying to do some cleanup...

- My `:::note` in "Sign Certificates with Public Keys" guide is really a warning, so I switched it to `:::caution`. It could even be considered danger, but I want to avoid overuse of red and we use private key copying in examples elsewhere.
- I changed a `:::danger` in unsafe_routes docs to `:::caution`. I think the worst that happens here is you tear your hair out a little bit during setup, so I wouldn't consider this dangerous per se.
- "EXPERIMENTAL: asdf" looked a little jarring to me on the relays page, so I reworded it. I also want to encourage people to use it as it's a very useful tool. I changed it from `:::note` to `:::caution` because we use caution for other experimental notes (e.g. DNS.)
- Clarified ciphers used and recommended AES.
- Explained how `relays.relays` works a little more as it's "backwards" of what most seem to expect.
- Moved things around a little bit in the DNS guide to try to get to the meat of it quicker, and moved limitations further down the page (also fleshed them out a bit more.) The DNS hostname validity tool now lives under the Limitations section.