### PR TITLE
Update config docs in-line with example config

### DIFF
--- a/docs/config/cipher.mdx
+++ b/docs/config/cipher.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
+description: Selection of cipher used by the network
 ---
 
 # cipher

--- a/docs/config/firewall.mdx
+++ b/docs/config/firewall.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 11
+sidebar_position: 13
+description: Configure firewall rules for this host
 ---
 
 # firewall
@@ -58,12 +59,17 @@ The possible fields of a firewall rule are:
 
 - `cidr`: a CIDR, `0.0.0.0/0` is any.
 
+- `local_cidr`: a local CIDR, `0.0.0.0/0` is any. This could be used to filter destinations when using unsafe_routes.
+
 Logical evaluation is roughly: port AND proto AND (ca_sha OR ca_name) AND (host OR group OR groups OR cidr).
 
 ```yml
 # Nebula security group configuration
 
 firewall:
+  outbound_action: drop
+  inbound_action: drop
+
   conntrack:
     tcp_timeout: 12m
     udp_timeout: 3m
@@ -117,3 +123,15 @@ conntrack:
   udp_timeout: 3m
   default_timeout: 10m
 ```
+
+## outbound_action, inbound_action
+
+<Pill className="mb-24">Default: drop</Pill>
+
+Action to take when a packet is not allowed by the firewall rules.
+
+Can be one of:
+ * `drop`: silently drop the packet.
+ * `reject`: send a reject reply.
+    - For TCP, this will be a RST "Connection Reset" packet.
+    - For other protocols, this will be an ICMP port unreachable packet.

--- a/docs/config/firewall.mdx
+++ b/docs/config/firewall.mdx
@@ -3,6 +3,8 @@ sidebar_position: 13
 description: Configure firewall rules for this host
 ---
 
+import { Pill } from '@components/Pill/Pill';
+
 # firewall
 
 The default state of the Nebula interface host firewall is _deny all_ for all inbound and outbound traffic. Firewall

--- a/docs/config/firewall.mdx
+++ b/docs/config/firewall.mdx
@@ -131,7 +131,8 @@ conntrack:
 Action to take when a packet is not allowed by the firewall rules.
 
 Can be one of:
- * `drop`: silently drop the packet.
- * `reject`: send a reject reply.
-    - For TCP, this will be a RST "Connection Reset" packet.
-    - For other protocols, this will be an ICMP port unreachable packet.
+
+- `drop`: silently drop the packet.
+- `reject`: send a reject reply.
+  - For TCP, this will be a RST "Connection Reset" packet.
+  - For other protocols, this will be an ICMP port unreachable packet.

--- a/docs/config/handshake.mdx
+++ b/docs/config/handshake.mdx
@@ -3,6 +3,8 @@ sidebar_position: 16
 description: Handshake Manager Settings
 ---
 
+import { Pill } from '@components/Pill/Pill';
+
 # handshakes
 
 ## handshakes.try_interval

--- a/docs/config/handshake.mdx
+++ b/docs/config/handshake.mdx
@@ -1,0 +1,16 @@
+---
+sidebar_position: 16
+description: Handshake Manager Settings
+---
+
+# handshakes
+
+#handshakes:
+  # Handshakes are sent to all known addresses at each interval with a linear backoff,
+  # Wait try_interval after the 1st attempt, 2 * try_interval after the 2nd, etc, until the handshake is older than timeout
+  # A 100ms interval with the default 10 retries will give a handshake 5.5 seconds to resolve before timing out
+  #try_interval: 100ms
+  #retries: 20
+  # trigger_buffer is the size of the buffer channel for quickly sending handshakes
+  # after receiving the response for lighthouse queries
+  #trigger_buffer: 64

--- a/docs/config/handshake.mdx
+++ b/docs/config/handshake.mdx
@@ -5,12 +5,29 @@ description: Handshake Manager Settings
 
 # handshakes
 
-#handshakes:
-  # Handshakes are sent to all known addresses at each interval with a linear backoff,
-  # Wait try_interval after the 1st attempt, 2 * try_interval after the 2nd, etc, until the handshake is older than timeout
-  # A 100ms interval with the default 10 retries will give a handshake 5.5 seconds to resolve before timing out
-  #try_interval: 100ms
-  #retries: 20
-  # trigger_buffer is the size of the buffer channel for quickly sending handshakes
-  # after receiving the response for lighthouse queries
-  #trigger_buffer: 64
+## handshakes.try_interval
+
+<Pill className="mb-24">Default: 100ms</Pill>
+
+Handshakes are sent to all known addresses at each interval with a linear backoff, waiting `try_interval` after the 1st
+attempt, 2 \* `try_interval` after the 2nd, etc, until the handshake is older than timeout.
+
+## handshakes.retries
+
+<Pill className="mb-24">Default: 10</Pill>
+
+A 100ms interval with the default 10 retries will give a handshake 5.5 seconds to resolve before timing out.
+
+## handshakes.trigger_buffer
+
+<Pill className="mb-24">Default: 64</Pill>
+
+`trigger_buffer` is the size of the buffer channel for quickly sending handshakes after receiving the response for
+lighthouse queries.
+
+```yml
+handshakes:
+  try_interval: 100ms
+  retries: 10
+  trigger_buffer: 64
+```

--- a/docs/config/lighthouse.mdx
+++ b/docs/config/lighthouse.mdx
@@ -31,8 +31,8 @@ lighthouse:
     '10.0.0.0/8': true
 
   advertise_addrs:
-    - "1.1.1.1:4242"
-    - "1.2.3.4:0" # port will be replaced with the real listening port
+    - '1.1.1.1:4242'
+    - '1.2.3.4:0' # port will be replaced with the real listening port
 
   calculated_remotes:
     10.0.10.0/24:
@@ -179,19 +179,20 @@ lighthouse:
 
 ## lighthous.advertise_addrs
 
-advertise_addrs are routable addresses that will be included along with discovered addresses to report to the lighthouse,
-the format is "ip:port". `port` can be `0`, in which case the actual listening port will be used in its place, useful if 
-`listen.port` is set to 0. This option is mainly useful when there are static ip addresses the host can be reached at 
-that nebula can not typically discover on its own. Examples being port forwarding or multiple paths to the internet.
+advertise_addrs are routable addresses that will be included along with discovered addresses to report to the
+lighthouse, the format is "ip:port". `port` can be `0`, in which case the actual listening port will be used in its
+place, useful if `listen.port` is set to 0. This option is mainly useful when there are static ip addresses the host can
+be reached at that nebula can not typically discover on its own. Examples being port forwarding or multiple paths to the
+internet.
 
 ## lighthouse.calculated_remotes
 
-EXPERIMENTAL: This option may change or disappear in the future. This setting allows us to "guess" what the remote might 
+EXPERIMENTAL: This option may change or disappear in the future. This setting allows us to "guess" what the remote might
 be for a host while we wait for the lighthouse response.
 
-For any Nebula IPs in the range, it will apply the mask and add the calculated IP as the initial remote (while we wait for
-the response from the lighthouse). Both CIRRs must have the same mask size. For example, Nebula IP 10.0.10.123 will have a
-calculated remote of 192.168.1.123.
+For any Nebula IPs in the range, it will apply the mask and add the calculated IP as the initial remote (while we wait
+for the response from the lighthouse). Both CIRRs must have the same mask size. For example, Nebula IP 10.0.10.123 will
+have a calculated remote of 192.168.1.123.
 
 ```yml
 calculated_remotes:

--- a/docs/config/lighthouse.mdx
+++ b/docs/config/lighthouse.mdx
@@ -179,19 +179,23 @@ lighthouse:
 
 ## lighthous.advertise_addrs
 
-advertise_addrs are routable addresses that will be included along with discovered addresses to report to the
-lighthouse, the format is "ip:port". `port` can be `0`, in which case the actual listening port will be used in its
-place, useful if `listen.port` is set to 0. This option is mainly useful when there are static ip addresses the host can
-be reached at that nebula can not typically discover on its own. Examples being port forwarding or multiple paths to the
-internet.
+`advertise_addrs` are routable addresses that will be included along with discovered addresses to report to the
+lighthouse. The format is "ip:port". `port` can be `0`, in which case the actual listening port will be used in its
+place, useful if `listen.port` is set to `0`. This option is mainly useful when there are static ip addresses the host
+can be reached at that nebula can not typically discover on its own. Examples being port forwarding or multiple paths to
+the internet.
 
 ## lighthouse.calculated_remotes
 
-EXPERIMENTAL: This option may change or disappear in the future. This setting allows us to "guess" what the remote might
-be for a host while we wait for the lighthouse response.
+:::danger
 
-For any Nebula IPs in the range, it will apply the mask and add the calculated IP as the initial remote (while we wait
-for the response from the lighthouse). Both CIRRs must have the same mask size. For example, Nebula IP 10.0.10.123 will
+EXPERIMENTAL: This option may change or disappear in the future. This setting allows nebula to "guess" what the remote
+might be for a host while it waits for the lighthouse response.
+
+:::
+
+For any Nebula IPs in the range, it will apply the mask and add the calculated IP as the initial remote (while it waits
+for the response from the lighthouse). Both CIDRs must have the same mask size. For example, Nebula IP 10.0.10.123 will
 have a calculated remote of 192.168.1.123.
 
 ```yml

--- a/docs/config/lighthouse.mdx
+++ b/docs/config/lighthouse.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 description: Lighthouse configuration reference for Nebula mesh networking.
 ---
 
@@ -29,6 +29,15 @@ lighthouse:
       tun0: false
       'docker.*': false
     '10.0.0.0/8': true
+
+  advertise_addrs:
+    - "1.1.1.1:4242"
+    - "1.2.3.4:0" # port will be replaced with the real listening port
+
+  calculated_remotes:
+    10.0.10.0/24:
+      - mask: 192.168.1.0/24
+        port: 4242
 ```
 
 ## lighthouse.am_lighthouse
@@ -43,7 +52,7 @@ configured to be lighthouses in your network
 <Pill className="mb-24">Default: False</Pill>
 
 `serve_dns` optionally starts a DNS listener that responds to `A` and `TXT` queries and can even be delegated to for
-name resolution by external DNS hosts.
+name resolution by external DNS hosts. To enable listening on IPv6 in addition to IPv4, use `'[::]'`.
 
 The DNS listener can only respond to requests about hosts it's aware of. For this reason, it can only be enabled on
 Lighthouses.
@@ -166,4 +175,27 @@ lighthouse:
       'docker.*': false
     # Example to only advertise this subnet to the lighthouse.
     '10.0.0.0/8': true
+```
+
+## lighthous.advertise_addrs
+
+advertise_addrs are routable addresses that will be included along with discovered addresses to report to the lighthouse,
+the format is "ip:port". `port` can be `0`, in which case the actual listening port will be used in its place, useful if 
+`listen.port` is set to 0. This option is mainly useful when there are static ip addresses the host can be reached at 
+that nebula can not typically discover on its own. Examples being port forwarding or multiple paths to the internet.
+
+## lighthouse.calculated_remotes
+
+EXPERIMENTAL: This option may change or disappear in the future. This setting allows us to "guess" what the remote might 
+be for a host while we wait for the lighthouse response.
+
+For any Nebula IPs in the range, it will apply the mask and add the calculated IP as the initial remote (while we wait for
+the response from the lighthouse). Both CIRRs must have the same mask size. For example, Nebula IP 10.0.10.123 will have a
+calculated remote of 192.168.1.123.
+
+```yml
+calculated_remotes:
+  10.0.10.0/24:
+    - mask: 192.168.1.0/24
+      port: 4242
 ```

--- a/docs/config/listen.mdx
+++ b/docs/config/listen.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
+description: Configuration of the UDP port used for sending/receiving traffic
 ---
 
 import { Pill } from '@components/Pill/Pill';
@@ -21,8 +22,8 @@ listen:
 
 <Pill className="mb-24">Default: 0.0.0.0</Pill>
 
-`host` is the ip of the interface to use when binding the listener. The default is 0.0.0.0, which is what most people
-should use.
+`host` is the ip of the interface to use when binding the listener. The default is `0.0.0.0` for all IPv4 interfaces. 
+To enable IPv6, use `'[::]'` instead. `host` may also contain a hostname.
 
 ## listen.port
 

--- a/docs/config/listen.mdx
+++ b/docs/config/listen.mdx
@@ -22,8 +22,8 @@ listen:
 
 <Pill className="mb-24">Default: 0.0.0.0</Pill>
 
-`host` is the ip of the interface to use when binding the listener. The default is `0.0.0.0` for all IPv4 interfaces. 
-To enable IPv6, use `'[::]'` instead. `host` may also contain a hostname.
+`host` is the ip of the interface to use when binding the listener. The default is `0.0.0.0` for all IPv4 interfaces. To
+enable IPv6, use `'[::]'` instead. `host` may also contain a hostname.
 
 ## listen.port
 

--- a/docs/config/local-range.mdx
+++ b/docs/config/local-range.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 14
+sidebar_position: 17
+description: Deprecated in favor of preferred_ranges
 ---
 
 # local_range

--- a/docs/config/logging.mdx
+++ b/docs/config/logging.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 12
 description: Logging configuration reference for Nebula mesh networking.
 ---
 

--- a/docs/config/pki.mdx
+++ b/docs/config/pki.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Define the path of each required certificate file
 ---
 
 import { Pill } from '@components/Pill/Pill';

--- a/docs/config/preferred-ranges.mdx
+++ b/docs/config/preferred-ranges.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
+description: Set the priority order of underlay IP addresses
 ---
 
 # preferred_ranges

--- a/docs/config/punchy.mdx
+++ b/docs/config/punchy.mdx
@@ -32,6 +32,12 @@ punchy:
 establish a tunnel, which can be the case when hole punching fails in one direction. This can be extremely useful if one
 node is behind a difficult nat, such as a symmetric NAT.
 
+## punchy.respond_delay
+
+<Pill className="mb-24">Default: 5s</Pill>
+
+Delay before attempting punchy.respond. respond must be true to take effect.
+
 ## punchy.delay
 
 <Pill className="mb-24">Default: 1s</Pill>
@@ -39,9 +45,3 @@ node is behind a difficult nat, such as a symmetric NAT.
 `delay` slows down punch responses which can be helpful for conditions where a NAT is unable to handle certain race
 conditions. `respond` must be true to take effect. Changing this value while running will not affect any in progress
 operations, only new ones.
-
-## punchy.respond_delay
-
-<Pill className="mb-24">Default: 5s</Pill>
-
-Delay before attempting punchy.respond. respond must be true to take effect.

--- a/docs/config/punchy.mdx
+++ b/docs/config/punchy.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
+description: Configuration of keep-alive packets to avoid expiration of firewall and NAT mappings
 ---
 
 import { Pill } from '@components/Pill/Pill';
@@ -14,6 +15,7 @@ punchy:
   punch: true
   respond: true
   delay: 1s
+  respond_delay: 5s
 ```
 
 ## punchy.punch
@@ -37,3 +39,9 @@ node is behind a difficult nat, such as a symmetric NAT.
 `delay` slows down punch responses which can be helpful for conditions where a NAT is unable to handle certain race
 conditions. `respond` must be true to take effect. Changing this value while running will not affect any in progress
 operations, only new ones.
+
+## punchy.respond_delay
+
+<Pill className="mb-24">Default: 5s</Pill>
+
+Delay before attempting punchy.respond. respond must be true to take effect.

--- a/docs/config/relay.mdx
+++ b/docs/config/relay.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
+description: Configuration of peers which can relay packets to this host
 ---
 
 # relay

--- a/docs/config/routines.mdx
+++ b/docs/config/routines.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 14
 description: Routines configuration reference for Nebula mesh networking.
 ---
 

--- a/docs/config/sshd.mdx
+++ b/docs/config/sshd.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 import { Pill } from '@components/Pill/Pill';

--- a/docs/config/static-host-map.mdx
+++ b/docs/config/static-host-map.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: Define the static host map for clients
 ---
 
 # static_host_map

--- a/docs/config/static-map.mdx
+++ b/docs/config/static-map.mdx
@@ -7,7 +7,7 @@ import { Pill } from '@components/Pill/Pill';
 
 # static_map
 
-The static map defines options which control the interpretation of the static_host_map. 
+The static map defines options which control the interpretation of the static_host_map.
 
 Example:
 
@@ -22,7 +22,7 @@ static_map:
 
 <Pill className="mb-24">Default: ip4</Pill>
 
-Select the IP version used to communicate with hosts in the static map. Valid values are `ip`, `ip4`, and `ip6`. 
+Select the IP version used to communicate with hosts in the static map. Valid values are `ip`, `ip4`, and `ip6`.
 
 ## static_map.cadence
 
@@ -35,4 +35,3 @@ Interval to retry DNS lookups of static hosts
 <Pill className="mb-24">Default: 250ms</Pill>
 
 Timeout for DNS lookup of static hosts
-

--- a/docs/config/static-map.mdx
+++ b/docs/config/static-map.mdx
@@ -1,0 +1,38 @@
+---
+sidebar_position: 3
+description: Define options for the static host map
+---
+
+import { Pill } from '@components/Pill/Pill';
+
+# static_map
+
+The static map defines options which control the interpretation of the static_host_map. 
+
+Example:
+
+```yml
+static_map:
+  network: ip4
+  cadence: 30s
+  lookup_timeout: 250ms
+```
+
+## static_map.network
+
+<Pill className="mb-24">Default: ip4</Pill>
+
+Select the IP version used to communicate with hosts in the static map. Valid values are `ip`, `ip4`, and `ip6`. 
+
+## static_map.cadence
+
+<Pill className="mb-24">Default: 30s</Pill>
+
+Interval to retry DNS lookups of static hosts
+
+## static_map.lookup_timeout
+
+<Pill className="mb-24">Default: 250ms</Pill>
+
+Timeout for DNS lookup of static hosts
+

--- a/docs/config/stats.mdx
+++ b/docs/config/stats.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 15
 description: Stats configuration reference for Nebula mesh networking.
 ---
 

--- a/docs/config/tun.mdx
+++ b/docs/config/tun.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 description: Tun configuration reference for Nebula mesh networking.
 ---
 
@@ -22,6 +22,7 @@ tun:
     - route: 172.16.1.0/24
       via: 192.168.100.99
       mtu: 1300 #mtu will default to tun mtu if this option is not specified
+      install: true #controls whether this route is installed in the systems routing table.
 ```
 
 ## tun.disabled
@@ -92,4 +93,12 @@ tun:
       via: 192.168.100.99
       mtu: 1300
       metric: 100
+      install: true #controls whether this route is installed in the systems routing table.
 ```
+
+## tun.use_system_route_table
+
+<Pill className="mb-24">Default: False</Pill>
+
+On linux only, set to true to manage unsafe routes directly on the system route table with gateway routes instead of 
+in nebula configuration files.

--- a/docs/config/tun.mdx
+++ b/docs/config/tun.mdx
@@ -100,5 +100,5 @@ tun:
 
 <Pill className="mb-24">Default: False</Pill>
 
-On linux only, set to true to manage unsafe routes directly on the system route table with gateway routes instead of 
-in nebula configuration files.
+On linux only, set to true to manage unsafe routes directly on the system route table with gateway routes instead of in
+nebula configuration files.

--- a/docs/config/tun.mdx
+++ b/docs/config/tun.mdx
@@ -21,8 +21,8 @@ tun:
   unsafe_routes:
     - route: 172.16.1.0/24
       via: 192.168.100.99
-      mtu: 1300 #mtu will default to tun mtu if this option is not specified
-      install: true #controls whether this route is installed in the systems routing table.
+      mtu: 1300 # mtu will default to tun mtu if this option is not specified
+      install: true # controls whether this route is installed in the systems routing table.
 ```
 
 ## tun.disabled
@@ -93,7 +93,7 @@ tun:
       via: 192.168.100.99
       mtu: 1300
       metric: 100
-      install: true #controls whether this route is installed in the systems routing table.
+      install: true # controls whether this route is installed in the systems routing table.
 ```
 
 ## tun.use_system_route_table

--- a/docs/guides/using-lighthouse-dns/index.mdx
+++ b/docs/guides/using-lighthouse-dns/index.mdx
@@ -28,7 +28,7 @@ First, spin up a lighthouse and 2 hosts. Then add
 lighthouse:
   serve_dns: true
   dns:
-    host: [::]
+    host: '[::]'
     port: 53
 ```
 
@@ -51,7 +51,7 @@ allow any host on the nebula network:
 firewall:
   inbound:
     - port: 53
-      proto: UDP
+      proto: udp
       group: any
 ```
 


### PR DESCRIPTION
There are still too many undocumented options in the code, but this at least brings the docs to match the example config and descriptions listed there.