### PR TITLE
Add aside reccomending Console.app on macOS for logs viewing

### DIFF
--- a/docs/guides/viewing-nebula-logs/index.mdx
+++ b/docs/guides/viewing-nebula-logs/index.mdx
@@ -57,6 +57,8 @@ On Intel processors, Homebrew uses `/usr/local` instead of `/opt/homebrew` as a 
 sudo tail -f /opt/homebrew/var/log/nebula.*
 ```
 
+Another useful tool for viewing the logs can be `Console.app` it provides a nice UI for viewing logs in.
+
 ### Service status
 
 ```bash


### PR DESCRIPTION
Console.app is a pretty useful tool for watching logs, seems useful to mention.