### PR TITLE
Document reloadable configs

### DIFF
--- a/docs/config/firewall.mdx
+++ b/docs/config/firewall.mdx
@@ -116,6 +116,8 @@ firewall:
 
 ## firewall.outbound
 
+<Pill className="mb-24">Reloadable</Pill>
+
 It is quite common to allow any outbound traffic to flow from a host. This simply means that the host can use any port
 or protocol to attempt to connect to any other host in the overlay network. (Whether or not those other hosts allow that
 inbound traffic is up to them.)
@@ -129,12 +131,14 @@ outbound:
 
 ## firewall.inbound
 
+<Pill className="mb-24">Reloadable</Pill>
+
 At a minimum, it is recommended to enable ICMP so that `ping` can be used to verify connectivity. Additionally, if
 enabling the built-in Nebula SSH server, you may wish to grant access over the Nebula network via firewall rules.
 
 ## firewall.default_local_cidr_any
 
-<Pill className="mb-24">Default: True</Pill>
+<Pill className="mb-24">Default: True</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 This setting was introduced in Nebula v1.9.0 for backwards compatibility purposes. The default will be changed to
 `false` in Nebula v1.10.0 and the config option will be deprecated.
@@ -149,6 +153,8 @@ in the `local_cidr` field.
 
 ## firewall.conntrack
 
+<Pill className="mb-24">Reloadable</Pill>
+
 Settings for the Connection Tracker.
 
 ```yml
@@ -160,7 +166,7 @@ conntrack:
 
 ## outbound_action, inbound_action
 
-<Pill className="mb-24">Default: drop</Pill>
+<Pill className="mb-24">Default: drop</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 Action to take when a packet is not allowed by the firewall rules.
 

--- a/docs/config/lighthouse.mdx
+++ b/docs/config/lighthouse.mdx
@@ -118,13 +118,15 @@ lighthouse:
 
 ## lighthouse.interval
 
-<Pill className="mb-24">Default: 10</Pill>
+<Pill className="mb-24">Default: 10</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 `interval` specifies how often a nebula host should report itself to a lighthouse. By default, hosts report themselves
 to lighthouses once every 10 seconds. Use caution when changing this interval, as it may affect host discovery times in
 a large nebula network.
 
 ## lighthouse.hosts
+
+<Pill className="mb-24">Reloadable</Pill>
 
 :::warning
 
@@ -142,6 +144,8 @@ lighthouse:
 ```
 
 ## lighthouse.remote_allow_list
+
+<Pill className="mb-24">Reloadable</Pill>
 
 `remote_allow_list` allows you to control ip ranges that this node will consider when handshaking to another node. By
 default, any remote IPs are allowed. You can provide CIDRs here with `true` to allow and `false` to deny. The most
@@ -162,6 +166,8 @@ lighthouse:
 
 ## lighthouse.local_allow_list
 
+<Pill className="mb-24">Reloadable</Pill>
+
 `local_allow_list` allows you to filter which local IP addresses we advertise to the lighthouses. This uses the same
 logic as `remote_allow_list`, but additionally, you can specify an `interfaces` map of regular expressions to match
 against interface names. The regexp must match the entire name. All interface rules must be either true or false (and
@@ -180,6 +186,8 @@ lighthouse:
 
 ## lighthouse.advertise_addrs
 
+<Pill className="mb-24">Reloadable</Pill>
+
 `advertise_addrs` are routable addresses that will be included along with discovered addresses to report to the
 lighthouse. The format is "ip:port". `port` can be `0`, in which case the actual listening port will be used in its
 place, useful if `listen.port` is set to `0`. This option is mainly useful when there are static IP addresses the host
@@ -187,6 +195,8 @@ can be reached at that nebula can not typically discover on its own (e.g. when p
 multiple paths to the internet.)
 
 ## lighthouse.calculated_remotes
+
+<Pill className="mb-24">Reloadable</Pill>
 
 :::danger
 

--- a/docs/config/logging.mdx
+++ b/docs/config/logging.mdx
@@ -17,23 +17,25 @@ logging:
 
 ## logging.level
 
-<Pill className="mb-24">Default: info</Pill>
+<Pill className="mb-24">Default: info</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 Controls the verbosity of logs. The options are `panic`, `fatal`, `error`, `warning`, `info`, or `debug`.
 
 ## logging.format
 
-<Pill className="mb-24">Default: text</Pill>
+<Pill className="mb-24">Default: text</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 Controls the logging format. The options are `json` or `text`
 
 ## logging.disable_timestamp
 
-<Pill className="mb-24">Default: False</Pill>
+<Pill className="mb-24">Default: False</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 Disables timestamp logging. Useful when output is redirected to logging system that already adds timestamps.
 
 ## logging.timestamp_format
+
+<Pill className="mb-24">Reloadable</Pill>
 
 `timestamp_format` is specified in Go time format, see: https://golang.org/pkg/time/#pkg-constants.
 

--- a/docs/config/pki.mdx
+++ b/docs/config/pki.mdx
@@ -41,6 +41,13 @@ pki:
 
 <Pill className="mb-24">Required</Pill> <Pill className="mb-24">Reloadable</Pill>
 
+:::note
+
+A new certificate will only take effect after a reload if the IP address has not changed, but all other properties of
+the certificate can be changed.
+
+:::
+
 The `cert` is a certificate unique to every host on a Nebula network. The certificate identifies a host’s IP address,
 name, and group membership within a Nebula network. The certificate is signed by a certificate authority when created,
 which informs other hosts on whether to trust a particular host certificate.

--- a/docs/config/pki.mdx
+++ b/docs/config/pki.mdx
@@ -21,7 +21,7 @@ pki:
 
 ## pki.ca
 
-<Pill className="mb-24">Required</Pill>
+<Pill className="mb-24">Required</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 The `ca` is a collection of one or more certificate authorities this host should trust. In the above example,
 `/etc/nebula/ca.crt` contains PEM-encoded data for each CA we should trust, concatenated into a single file. The
@@ -39,7 +39,7 @@ pki:
 
 ## pki.cert
 
-<Pill className="mb-24">Required</Pill>
+<Pill className="mb-24">Required</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 The `cert` is a certificate unique to every host on a Nebula network. The certificate identifies a host’s IP address,
 name, and group membership within a Nebula network. The certificate is signed by a certificate authority when created,
@@ -47,13 +47,15 @@ which informs other hosts on whether to trust a particular host certificate.
 
 ## pki.key
 
-<Pill className="mb-24">Required</Pill>
+<Pill className="mb-24">Required</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 The `key` is a private key unique to every host on a Nebula network. It is used in conjunction with the host certificate
 to prove a host’s identity to other members of the Nebula network. The private key should never be shared with other
 hosts.
 
 ## pki.blocklist
+
+<Pill className="mb-24">Reloadable</Pill>
 
 :::note
 
@@ -69,6 +71,6 @@ stolen or compromised.
 
 ## pki.disconnect_invalid
 
-<Pill className="mb-24">Default: False</Pill>
+<Pill className="mb-24">Default: False</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 `disconnect_invalid` is a toggle to force a client to be disconnected if the certificate is expired or invalid.

--- a/docs/config/preferred-ranges.mdx
+++ b/docs/config/preferred-ranges.mdx
@@ -3,7 +3,11 @@ sidebar_position: 8
 description: Configure the priority order of underlay IP addresses to increase performance and reduce latency.
 ---
 
+import { Pill } from '@components/Pill/Pill';
+
 # preferred_ranges
+
+<Pill className="mb-24">Reloadable</Pill>
 
 `preferred_ranges` sets the priority order for underlay IP addresses. Two hosts on the same LAN would likely benefit
 from having their tunnels use the LAN IP addresses rather than the public IP addresses the lighthouse may have learned

--- a/docs/config/punchy.mdx
+++ b/docs/config/punchy.mdx
@@ -26,7 +26,7 @@ punchy:
 
 ## punchy.respond
 
-<Pill className="mb-24">Default: False</Pill>
+<Pill className="mb-24">Default: False</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 `respond` means that a node unable to receive handshakes will attempt to initiate a handshake to the host attempting to
 establish a tunnel, which can be the case when hole punching fails in one direction. This can be extremely useful if one
@@ -34,13 +34,13 @@ node is behind a difficult nat, such as a symmetric NAT.
 
 ## punchy.respond_delay
 
-<Pill className="mb-24">Default: 5s</Pill>
+<Pill className="mb-24">Default: 5s</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 Delay before attempting punchy.respond. respond must be true to take effect.
 
 ## punchy.delay
 
-<Pill className="mb-24">Default: 1s</Pill>
+<Pill className="mb-24">Default: 1s</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 `delay` slows down punch responses which can be helpful for conditions where a NAT is unable to handle certain race
 conditions. `respond` must be true to take effect. Changing this value while running will not affect any in progress

--- a/docs/config/relay.mdx
+++ b/docs/config/relay.mdx
@@ -3,6 +3,8 @@ sidebar_position: 9
 description: Configure Nebula relays to forward packets between hosts with tricky connectivity issues.
 ---
 
+import { Pill } from '@components/Pill/Pill';
+
 # relay
 
 :::note
@@ -36,6 +38,8 @@ their own config.
 
 ## relay.relays
 
+<Pill className="mb-24">Reloadable</Pill>
+
 `relays` is a list of Nebula IPs that peers can use to relay packets to this host. IPs in this list must have `am_relay`
 set to `true` in their configs, otherwise they will reject relay requests.
 
@@ -49,6 +53,8 @@ This list of relays is reported to the Lighthouse. When other nodes attempt to h
 will indicate its supported relays in addition to its known IP addresses.
 
 ## relay.am_relay
+
+<Pill className="mb-24">Reloadable</Pill>
 
 Set `am_relay` to true to enable forwarding packets for other hosts. This host will only forward traffic for hosts which
 specify it as a relay in their own config file. The default is false.

--- a/docs/config/sshd.mdx
+++ b/docs/config/sshd.mdx
@@ -30,16 +30,20 @@ See also the [Debugging with Nebula SSH commands](/docs/guides/debug-ssh-command
 
 ## sshd.enabled
 
-<Pill className="mb-24">Default: False</Pill>
+<Pill className="mb-24">Default: False</Pill> <Pill className="mb-24">Reloadable</Pill>
 
 `enabled` toggles this feature globally.
 
 ## sshd.listen
 
+<Pill className="mb-24">Reloadable</Pill>
+
 `listen` is used to specify the host ip and port number for the nebula debug console to listen on, port 22 is not
 allowed for your safety.
 
 ## sshd.host_key
+
+<Pill className="mb-24">Reloadable</Pill>
 
 `host_key` points to a file containing the ssh host private key to use for the ssh server side of the console. In the
 above example, `/path/to/ssh_host_ed25519_key` contains a PEM-encoded SSH host key. The following example shows a host
@@ -69,6 +73,8 @@ You can generate a host key using the `ssh-keygen` command line utility.
 `ssh-keygen -t ed25519 -f ssh_host_ed25519_key -N "" < /dev/null`
 
 ## sshd.authorized_users, user, keys
+
+<Pill className="mb-24">Reloadable</Pill>
 
 These options are how you create `users` for the debug ssh daemon. Password authentication for the ssh debug console is
 NOT supported.

--- a/docs/config/tun.mdx
+++ b/docs/config/tun.mdx
@@ -58,11 +58,13 @@ Default is 500.
 
 ## tun.mtu
 
-<Pill className="mb-24">Default: 1300</Pill>
+<Pill className="mb-24">Default: 1300</Pill> <Pill className="mb-24">Reloadable: Linux</Pill>
 
 Default MTU for every packet, safe setting is (and the default) 1300 for internet routed packets.
 
 ## tun.routes
+
+<Pill className="mb-24">Reloadable</Pill>
 
 Route based MTU overrides. If you have known VPN IP paths that can support larger MTUs you can increase/decrease them
 here.
@@ -75,6 +77,8 @@ tun:
 ```
 
 ## tun.unsafe_routes
+
+<Pill className="mb-24">Reloadable</Pill>
 
 :::warning
 


### PR DESCRIPTION
Closes https://github.com/DefinedNet/nebula-docs/issues/19

We didn't have any good listing of which options can be reloaded via a SIGHUP vs those that require a full restart to take effect.   This adds a simple badge to indicate which options can be reloaded.  AFAICT, `tun.mtu` is only reloadable on linux, but that's the only difference between platforms that I could find.  