### PR TITLE
Set `onBrokenAnchors` and `onBrokenMarkdownLinks` to `throw`

### DIFF
--- a/docusaurus.config.cjs
+++ b/docusaurus.config.cjs
@@ -150,6 +150,7 @@ const config = {
         darkTheme: darkCodeTheme,
       },
     },
+  onBrokenAnchors: 'throw',
 };
 
 module.exports = config;

--- a/docusaurus.config.cjs
+++ b/docusaurus.config.cjs
@@ -15,7 +15,8 @@ const config = {
   baseUrl: '/',
   trailingSlash: true,
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenMarkdownLinks: 'throw',
+  onBrokenAnchors: 'throw',
   favicon: 'img/favicon.ico',
 
   plugins: [
@@ -150,7 +151,6 @@ const config = {
         darkTheme: darkCodeTheme,
       },
     },
-  onBrokenAnchors: 'throw',
 };
 
 module.exports = config;


### PR DESCRIPTION
- https://docusaurus.io/blog/releases/3.4
	Can enforce that tags are either in the frontmatter or inline w/in content
- https://docusaurus.io/blog/releases/3.3
	Prepares for React 19
- https://docusaurus.io/blog/releases/3.2
	Faster builds
	Faster dev server
	MDX partials TOC (if you add headings via an MDX partial, they can be included in the table of contents now)
- https://docusaurus.io/blog/releases/3.1
	Broken anchors checker
	