### PR TITLE
Setup dependabot with weekly pnpm and GA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    schedule:
+      interval: 'weekly'
+    directories:
+      - '/'
+    groups:
+      docusaurus-dependencies:
+        patterns:
+          - '@docusaurus/*'
+      react-dependencies:
+        patterns:
+          - 'react-*'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
With weekly runs, this should keep nebula-docs up-to-date with minimal interaction and automatic PR creation.

Modelling the slackhq/nebula file: https://github.com/slackhq/nebula/blob/master/.github/dependabot.yml
