### PR TITLE
Reword "via" requirement in unsafe routes docs

### DIFF
--- a/docs/config/tun.mdx
+++ b/docs/config/tun.mdx
@@ -82,8 +82,8 @@ tun:
 
 :::warning
 
-The nebula certificate of the `via` node MUST have the `route` defined as a subnet in its certificate or it will refuse
-to route traffic.
+The nebula certificate of the `via` node MUST have the `route` defined in the subnets list in its certificate or it will
+silently refuse to route traffic.
 
 :::
 


### PR DESCRIPTION
This is a slight wording change suggested by a user that makes the silent refusal to route more obvious