### PR TITLE
Add guide to upgrading to cert-v2

### DIFF
--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -139,15 +139,12 @@ on v2 only. For a small network, it may be fine to simply change everything over
 After each step, you may validate that your changes have taken effect by using the `print-tunnel` command within the
 [debug ssh server](/docs/guides/debug-ssh-commands/).
 
-For example:
+For example, when debugging `nebula`'s tunnel to `lighthouse1` where both have both v1 and v2 certs and
+`pki.default_version` is set to `1` on both hosts, we can see that the certificate used in the tunnel is version 1.
 
 ```bash
-calebjasik@nebula > print-tunnel 192.168.1.1
-{"vpnAddrs":["192.168.1.1"],"localIndex":2965094606,"remoteIndex":1285130098,"remoteAddrs":["172.17.0.3:4242"],"cert":{"details":{"curve":"CURVE25519","groups":[],"isCa":fa
-lse,"issuer":"a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c","name":"lighthouse1","networks":["192.168.1.1/24"],"notAfter":"2026-03-11T17:26:18Z","notBef
-ore":"2025-03-18T17:14:43Z","publicKey":"c455bc023b1b3918538edf5f230169df12603703639db158c76da747e0eccc47","unsafeNetworks":[]},"fingerprint":"84cf960de2e49f7560a5c7f876857
-528f02ab201c906f5a094d0d3294732b655","signature":"6b9e98e398fb4c6a89f8e71e6a1378cecb85c500966443673a3ebe8f9d46702d0213dbd4c5028644104eeae49c06a4906058b53cd809e07dec76fcec60
-a4370d","version":1},"messageCounter":3,"currentRemote":"172.17.0.3:4242","currentRelaysToMe":[],"currentRelaysThroughMe":[]}
+steve@nebula > print-tunnel 192.168.1.2
+{"vpnAddrs":["192.168.1.2"],"localIndex":2965094606,"remoteIndex":1285130098,"remoteAddrs":["172.17.0.3:4242"],"cert":{"details":{"curve":"CURVE25519","groups":[],"isCa":false,"issuer":"a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c","name":"lighthouse1","networks":["192.168.1.2/24"],"notAfter":"2026-03-11T17:26:18Z","notBefore":"2025-03-18T17:14:43Z","publicKey":"c455bc023b1b3918538edf5f230169df12603703639db158c76da747e0eccc47","unsafeNetworks":[]},"fingerprint":"84cf960de2e49f7560a5c7f876857528f02ab201c906f5a094d0d3294732b655","signature":"6b9e98e398fb4c6a89f8e71e6a1378cecb85c500966443673a3ebe8f9d46702d0213dbd4c5028644104eeae49c06a4906058b53cd809e07dec76fcec60a4370d","version":1},"messageCounter":3,"currentRemote":"172.17.0.3:4242","currentRelaysToMe":[],"currentRelaysThroughMe":[]}
 ```
 
 ### Switch all non-lighthouse relays to use v2 certificates

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -17,8 +17,8 @@ import TOCInline from '@theme/TOCInline';
 
 ## Upgrade to nebula nightly
 
-First of all, download the updated nebula version that has v2 certs and IPv6 support from nightly releases, and move all
-of the hosts in your network to it.
+First, download the updated nebula version that has v2 certs and IPv6 support from nightly releases, and move all the
+hosts in your network to it.
 
 - [https://github.com/NebulaOSS/nebula-nightly/releases](https://github.com/NebulaOSS/nebula-nightly/releases)
 - [https://hub.docker.com/r/nebulaoss/nebula-nightly](https://hub.docker.com/r/nebulaoss/nebula-nightly)

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -116,18 +116,47 @@ Using `nebula-cert show` we can see that the certificate has both cert format ve
 }
 ```
 
-## Switch all relays to use v2 certificates
+## Move all hosts to only contain v2 certificates
 
-Switch all `am_relay: true` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet.
+Removing the v1 certificates allows non-backwards compatible features to be enabled in your nebula network, like IPv6
+and multiple IPv4 and IPv6 network subnets contained within a network overlay.
+
+The first step is to keep v1 certs on your hosts as backup, but to initiate tunnels with their v2 certs by default.
+Turning this setting on in steps allows you to detect issues with your config and reduce downtime in the case of a
+misconfig.
+
+What follows is a suggested order of operations, but the general goal is to slowly roll out these changes, starting with
+the hosts that you don't expect to be initiating tunnels. We leave the lighthouses for last, since they're the
+coordinating nodes, and hosts still on v1 only will not be able to communicate with the network with their lighthouse is
+on v2 only. For a small network, it may be fine to simply change everything over in one go!
+
+After each step, you may validate that your changes have taken effect by using the `print-tunnel` command within the
+[debug ssh server](/docs/guides/debug-ssh-commands/).
+
+For example:
+
+```bash
+calebjasik@nebula > print-tunnel 192.168.1.1
+{"vpnAddrs":["192.168.1.1"],"localIndex":2965094606,"remoteIndex":1285130098,"remoteAddrs":["172.17.0.3:4242"],"cert":{"details":{"curve":"CURVE25519","groups":[],"isCa":fa
+lse,"issuer":"a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c","name":"lighthouse1","networks":["192.168.1.1/24"],"notAfter":"2026-03-11T17:26:18Z","notBef
+ore":"2025-03-18T17:14:43Z","publicKey":"c455bc023b1b3918538edf5f230169df12603703639db158c76da747e0eccc47","unsafeNetworks":[]},"fingerprint":"84cf960de2e49f7560a5c7f876857
+528f02ab201c906f5a094d0d3294732b655","signature":"6b9e98e398fb4c6a89f8e71e6a1378cecb85c500966443673a3ebe8f9d46702d0213dbd4c5028644104eeae49c06a4906058b53cd809e07dec76fcec60
+a4370d","version":1},"messageCounter":3,"currentRemote":"172.17.0.3:4242","currentRelaysToMe":[],"currentRelaysThroughMe":[]}
+```
+
+### Switch all non-lighthouse relays to use v2 certificates
+
+Switch all `am_relay: true && am_lighthouse: false` hosts' `pki.default_version` to `2` or add it if it doesn't exist
+yet.
 
 Now, if a relay initiates a handshake, it will attempt to use a v2 cert first, but this is an uncommon flow.
 
-## Switch all non-lighthouse hosts to use v2 certificates
+### Switch all non-lighthouse hosts to use v2 certificates
 
 Switch all `am_lighthouse: false` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet. Lighthouses
 will reply to v2 hosts using v2 protocols.
 
-## Switch all lighthouses to use v2 certificates
+### Switch all lighthouses to use v2 certificates
 
 Switch all `am_lighthouse: true` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet. Now all of your
 hosts should be using their v2 certificate for initiating tunnels.

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -1,0 +1,198 @@
+---
+title: Upgrading your IPv4 Cert V1 network to an IPv4/IPv6 Cert V2 network
+summary:
+  This guide describes how to take an existing nebula network and upgrade it to use the new v2 certificates and enable
+  IPv6 addresses.
+---
+
+# Upgrading your IPv4 Cert V1 network to an IPv4/IPv6 Cert V2 network
+
+## Upgrade to nebula nightly
+
+First of all, download the updated nebula version that has v2 certs and IPv6 support from nightly releases, and move all
+of the hosts in your network to it.
+
+[https://hub.docker.com/r/nebulaoss/nebula-nightly](https://hub.docker.com/r/nebulaoss/nebula-nightly)
+
+[https://github.com/NebulaOSS/nebula-nightly/releases](https://github.com/NebulaOSS/nebula-nightly/releases)
+
+## Add a v2 Certificate Authority
+
+Next, create a new CA for your network, and add it to the trust bundle of every host on the network. Creating a new CA
+with the nightly version of nebula will create a v2 CA by default, with support for creating and signing both v1 and v2
+certificates.
+
+```go
+❯ nebula-cert ca -name "Nebula IPv6 Tutorial CA" -encrypt
+Enter passphrase:
+# typed in my password and pressed enter.
+```
+
+Using `nebula-cert print` we can see that this is a v2 certificate authority, with support for IPv6 addresses.
+
+```bash
+❯ nebula-cert print -path ./ca.crt
+{
+        "curve": "CURVE25519",
+        "details": {
+                "groups": null,
+                "isCa": true,
+                "issuer": "",
+                "name": "Nebula IPv6 Tutorial CA",
+                "networks": null,
+                "notAfter": "2026-03-11T12:26:19-05:00",
+                "notBefore": "2025-03-11T12:26:19-05:00",
+                "unsafeNetworks": null
+        },
+        "fingerprint": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
+        "publicKey": "4f1200baedc57f39adfc71e1b5409a3a7dc60fab4e1a2c4decaeb347a2ad4d75",
+        "signature": "e46d1f31e4b677fc4bbef9ebcf941261cd49e00fd4bf124e26b9fb7716d23e7588b0b6b87d276e625b30ef6fa32ced0aa46abee7b61d150907007586cd6e2203",
+        "version": 2
+}
+```
+
+Add the public key of the CA to the `pki.ca` list in the config for every nebula host:
+[https://nebula.defined.net/docs/config/pki/#pkica](https://nebula.defined.net/docs/config/pki/#pkica)
+
+## Re-issue v1+v2 certificates for every host with the v2 CA
+
+In order to move to a network where every host has ipv4 and ipv6, or every host has ipv6 only, it's recommended to start
+by re-issuing all hosts certificates with both v1 and v2 certificates for compatibility. Hosts will continue handshaking
+via the v1 cert while the network is being upgraded.
+
+You can create a new v1+v2 cert like this:
+
+```go
+❯ nebula-cert sign -name "nebula" -networks "192.168.1.1/24"
+Enter passphrase:
+# Entered my passphrase
+```
+
+By default, nebula-cert will create a v1 and v2 version of the certificate when creating and signing a certificate. This
+allows you to move from v1 to v2 seamlessly. v1 does not support IPv6 though, so we'll move to only v2 soon.
+
+Using `nebula-cert show` we can see that the certificate has both cert format versions:
+
+```go
+❯ nebula-cert print -path nebula.crt
+{
+        "details": {
+                "curve": "CURVE25519",
+                "groups": [],
+                "isCa": false,
+                "issuer": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
+                "name": "nebula",
+                "networks": [
+                        "192.168.1.1/24"
+                ],
+                "notAfter": "2026-03-11T12:26:18-05:00",
+                "notBefore": "2025-03-17T14:27:25-05:00",
+                "publicKey": "ba79878d86c88b8d679e2db2382a31f32177d5a27727a167ee94f8ef1e12793b",
+                "unsafeNetworks": []
+        },
+        "fingerprint": "c2292774eaadf83a0a25a051cb0c66a22df56733b8683104b317978547e99cbc",
+        "signature": "064c25cd0d2fe4db2af84c2cd9396053f200e79736c13fcf8abfc2458cb9f40be0a9563c5d05b0192b891ab48aec3a9d82a09527fda8632e6286546170e2700b",
+        "version": 1
+}
+{
+        "curve": "CURVE25519",
+        "details": {
+                "groups": null,
+                "isCa": false,
+                "issuer": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
+                "name": "nebula",
+                "networks": [
+                        "192.168.1.1/24"
+                ],
+                "notAfter": "2026-03-11T12:26:18-05:00",
+                "notBefore": "2025-03-17T14:27:25-05:00",
+                "unsafeNetworks": null
+        },
+        "fingerprint": "beef1fd9ea8a78164c53a83f5b3fb362dc1afa4c90ffb5db78c794be64286eca",
+        "publicKey": "ba79878d86c88b8d679e2db2382a31f32177d5a27727a167ee94f8ef1e12793b",
+        "signature": "8ae8314e87a2a8c6c85eb567b1db74f706dca74b9d748ee32f1c7b2ca6ad84946242bcf38c02b2a83a5109f07f4874bf84a331278ad21400c781c874ef392304",
+        "version": 2
+}
+```
+
+## Switch all relays to use v2 certificates
+
+Switch all `am_relay: true` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet.
+
+Now, if a relay initiates a handshake, it will attempt to use a v2 cert first, but this is an uncommon flow.
+
+## Switch all non-lighthouse hosts to use v2 certificates
+
+Switch all `am_lighthouse: false` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet. Lighthouses
+will reply to v2 hosts using v2 protocols.
+
+## Switch all lighthouses to use v2 certificates
+
+Switch all `am_lighthouse: true` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet. Now all of your
+hosts should be using their v2 certificate for initiating tunnels.
+
+## Re-issue v2 certificates for the hosts
+
+Now that every host on the network is communicating via v2 certificates, you can remove the v1 certificates by reissuing
+the certificates. Pass `-version 2` to only create certificates in the v2 certificate format. This will enable the non
+backwards compatible features of the v2 certificates.
+
+```go
+❯ nebula-cert sign -name "nebula" -networks "192.168.1.1/24" -version 2
+```
+
+```go
+❯ nebula-cert print -path nebula.crt
+{
+        "curve": "CURVE25519",
+        "details": {
+                "groups": null,
+                "isCa": false,
+                "issuer": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
+                "name": "nebula",
+                "networks": [
+                        "192.168.1.1/24"
+                ],
+                "notAfter": "2026-03-11T12:26:18-05:00",
+                "notBefore": "2025-03-17T16:06:48-05:00",
+                "unsafeNetworks": null
+        },
+        "fingerprint": "7260e59ca62a6a23ef8c6d5e912790fcb7073ffa1fe5da485d934a99d558c5ab",
+        "publicKey": "05baa0d1af10b89a8336c925a5c9b5fda5599943ee53a5bc742a573aa3e2753d",
+        "signature": "275229cd09228312171450fecc696776745dab88f6686e2a2577b764e4829a6566e3821e1101cdedb035e649fa70dc634300b3e628bf8ea839b6215ff68fdf02",
+        "version": 2
+}
+```
+
+You can also add an IPv6 address to your hosts now.
+
+```go
+❯ nebula-cert sign -name "nebula" -networks "192.168.1.1/24,fd0:0:0::1/64" -version 2
+```
+
+```go
+❯ nebula-cert print -path nebula.crt
+{
+        "curve": "CURVE25519",
+        "details": {
+                "groups": null,
+                "isCa": false,
+                "issuer": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
+                "name": "nebula",
+                "networks": [
+                        "192.168.1.1/24",
+                        "fd0::1/64"
+                ],
+                "notAfter": "2026-03-11T12:26:18-05:00",
+                "notBefore": "2025-03-17T16:11:30-05:00",
+                "unsafeNetworks": null
+        },
+        "fingerprint": "08e9d282adb0809457ad63982a9f1113a462763da58aa69b76d2b4cb1cd24724",
+        "publicKey": "ae950d4d0db966f93b5f463c9910d3fe9efd69347ddec4f3ed0f379c51712e0f",
+        "signature": "d156b2cd48916377426d8fab3286d176590ea48b83853f44f92089f1fb6d6bca9727b7169d3640e8a3418b3eac74159cb4368d847bd346663249d2dbbd81670e",
+        "version": 2
+}
+```
+
+Once you switch services over to use the new IPv6 addresses, you can decide to deprecate the IPv4 addresses or continue
+to run your overlay network with both IPv4 and IPv6 subnets.

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -14,9 +14,8 @@ With newly added IPv6 support to nebula, there are a few steps that must be take
 First of all, download the updated nebula version that has v2 certs and IPv6 support from nightly releases, and move all
 of the hosts in your network to it.
 
-[https://hub.docker.com/r/nebulaoss/nebula-nightly](https://hub.docker.com/r/nebulaoss/nebula-nightly)
-
-[https://github.com/NebulaOSS/nebula-nightly/releases](https://github.com/NebulaOSS/nebula-nightly/releases)
+- [https://github.com/NebulaOSS/nebula-nightly/releases](https://github.com/NebulaOSS/nebula-nightly/releases)
+- [https://hub.docker.com/r/nebulaoss/nebula-nightly](https://hub.docker.com/r/nebulaoss/nebula-nightly)
 
 ## Add a v2 Certificate Authority
 

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Upgrading your IPv4 Cert V1 network to an IPv4/IPv6 Cert V2 network
+title: Upgrading to IPv6 support
 summary:
   This guide describes how to take an existing nebula network and upgrade it to use the new v2 certificates and enable
   IPv6 addresses.
 ---
 
-# Upgrading your IPv4 Cert V1 network to an IPv4/IPv6 Cert V2 network
+# Upgrading to IPv6 support
 
 ## Upgrade to nebula nightly
 

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -139,8 +139,9 @@ on v2 only. For a small network, it may be fine to simply change everything over
 After each step, you may validate that your changes have taken effect by using the `print-tunnel` command within the
 [debug ssh server](/docs/guides/debug-ssh-commands/).
 
-For example, when debugging `nebula`'s tunnel to `lighthouse1` where both have both v1 and v2 certs and
-`pki.default_version` is set to `1` on both hosts, we can see that the certificate used in the tunnel is version 1.
+For example, when debugging `nebula(192.168.1.1)`'s tunnel to `lighthouse1(192.168.1.2)` where both have both v1 and v2
+certs and `pki.default_version` is set to `1` on both hosts, we can see that the certificate used in the tunnel is
+version 1.
 
 ```bash
 steve@nebula > print-tunnel 192.168.1.2

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -123,9 +123,9 @@ Using `nebula-cert print` we can see that the file contains both versions of the
 ```
 
 Update the corresponding [`pki.cert` field](https://nebula.defined.net/docs/config/pki/#pkicert) with the contents of
-the entire file, and **restart** Nebula. Nebula will continue to use the v1 certificate when initiating tunnels until
-we update the `pki.default_version` config option. When another host initiates a tunnel, Nebula will respond with the
-same certificate version it was presented.
+the entire file, and **restart** Nebula. Nebula will continue to use the v1 certificate when initiating tunnels until we
+update the `pki.default_version` config option. When another host initiates a tunnel, Nebula will respond with the same
+certificate version it was presented.
 
 :::note
 
@@ -141,7 +141,7 @@ certificate. To do this, we set the `pki.default_version` config option to 2.
 
 We recommend slow rolling this change by starting with a small subset of hosts and verifying the change before rolling
 it out widely. After updating the config option, reloading Nebula, and establishing a tunnel you can verify the v2
-certificate is in use via the  `print-tunnel` command from [debug SSH server](/docs/guides/debug-ssh-commands/).
+certificate is in use via the `print-tunnel` command from [debug SSH server](/docs/guides/debug-ssh-commands/).
 
 In this example we've updated host-1 (192.168.1.1) with `pki.default_version` set to 2 and restarted Nebula. Since its
 default version is set to 2, it'll use the v2 certificate when handshaking with the Lighthouse. Because the Lighthouse
@@ -150,10 +150,10 @@ to 1.
 
 :::note
 
-If the Lighthouse were configured with only a v1 certificate, host-1 would not be able to connect, even though it has
-a v1+v2 certificate bundle configured. This is because `pki.default_version` indicates the certificate version that
-should be used in outgoing handshakes. If the receiving end does not support v2 certificates, the initiator will not
-fallback on a v1 certificate.
+If the Lighthouse were configured with only a v1 certificate, host-1 would not be able to connect, even though it has a
+v1+v2 certificate bundle configured. This is because `pki.default_version` indicates the certificate version that should
+be used in outgoing handshakes. If the receiving end does not support v2 certificates, the initiator will not fallback
+on a v1 certificate.
 
 :::
 

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -180,6 +180,12 @@ steve@nebula > print-tunnel 192.168.1.2
 }
 ```
 
+You may also look in the host logs for the `certVersion` field in handshakes, ex:
+
+```perl
+time="2025-03-27T16:50:26-05:00" level=info msg="Handshake message received" certName=lighthouse1 certVersion=1 durationNs=63460958 fingerprint=84cf960de2e49f7560a5c7f876857528f02ab201c906f5a094d0d3294732b655 handshake="map[stage:2 style:ix_psk0]" initiatorIndex=530355834 issuer=a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c remoteIndex=530355834 responderIndex=3163624101 sentCachedPackets=1 udpAddr="172.17.0.3:4242" vpnAddrs="[192.168.1.2]"
+```
+
 ### Switch all non-lighthouse relays to use v2 certificates
 
 Switch all `am_relay: true && am_lighthouse: false` hosts' `pki.default_version` to `2` or add it if it doesn't exist

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -9,6 +9,12 @@ summary:
 
 With newly added IPv6 support to nebula, there are a few steps that must be taken to enable it across your network.
 
+The basic steps go:
+
+import TOCInline from '@theme/TOCInline';
+
+<TOCInline toc={toc} />
+
 ## Upgrade to nebula nightly
 
 First of all, download the updated nebula version that has v2 certs and IPv6 support from nightly releases, and move all

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -124,8 +124,8 @@ Using `nebula-cert print` we can see that the file contains both versions of the
 
 Update the corresponding [`pki.cert` field](https://nebula.defined.net/docs/config/pki/#pkicert) with the contents of
 the entire file, and **restart** Nebula. Nebula will continue to use the v1 certificate when initiating tunnels until we
-update the `pki.default_version` config option. When another host initiates a tunnel, Nebula will respond with the same
-certificate version it was presented.
+update the `pki.initiating_version` config option. When another host initiates a tunnel, Nebula will respond with the
+same certificate version it was presented.
 
 :::note
 
@@ -137,23 +137,23 @@ insufficient for this change.
 ## Start handshaking with v2 certificates
 
 Once all hosts are configured with a v1+v2 certificate bundle, we can switch over to handshaking with the v2
-certificate. To do this, we set the `pki.default_version` config option to 2.
+certificate. To do this, we set the `pki.initiating_version` config option to 2.
 
 We recommend slow rolling this change by starting with a small subset of hosts and verifying the change before rolling
 it out widely. After updating the config option, reloading Nebula, and establishing a tunnel you can verify the v2
 certificate is in use via the `print-tunnel` command from [debug SSH server](/docs/guides/debug-ssh-commands/).
 
-In this example we've updated host-1 (192.168.1.1) with `pki.default_version` set to 2 and restarted Nebula. Since its
-default version is set to 2, it'll use the v2 certificate when handshaking with the Lighthouse. Because the Lighthouse
-has a v1+v2 bundle configured it is able to complete the connection, even though its `pki.default_version` is still set
-to 1.
+In this example we've updated host-1 (192.168.1.1) with `pki.initiating_version` set to 2 and restarted Nebula. Since
+its default version is set to 2, it'll use the v2 certificate when handshaking with the Lighthouse. Because the
+Lighthouse has a v1+v2 bundle configured it is able to complete the connection, even though its `pki.initiating_version`
+is still set to 1.
 
 :::note
 
 If the Lighthouse were configured with only a v1 certificate, host-1 would not be able to connect, even though it has a
-v1+v2 certificate bundle configured. This is because `pki.default_version` indicates the certificate version that should
-be used in outgoing handshakes. If the receiving end does not support v2 certificates, the initiator will not fallback
-on a v1 certificate.
+v1+v2 certificate bundle configured. This is because `pki.initiating_version` indicates the certificate version that
+should be used in outgoing handshakes. If the receiving end does not support v2 certificates, the initiator will not
+fallback on a v1 certificate.
 
 :::
 

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -7,6 +7,8 @@ summary:
 
 # Upgrading to IPv6 support
 
+With newly added IPv6 support to nebula, there are a few steps that must be taken to enable it across your network.
+
 ## Upgrade to nebula nightly
 
 First of all, download the updated nebula version that has v2 certs and IPv6 support from nightly releases, and move all

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -24,7 +24,7 @@ Next, create a new CA for your network, and add it to the trust bundle of every 
 with the nightly version of nebula will create a v2 CA by default, with support for creating and signing both v1 and v2
 certificates.
 
-```go
+```bash
 ❯ nebula-cert ca -name "Nebula IPv6 Tutorial CA" -encrypt
 Enter passphrase:
 # typed in my password and pressed enter.
@@ -64,7 +64,7 @@ via the v1 cert while the network is being upgraded.
 
 You can create a new v1+v2 cert like this:
 
-```go
+```bash
 ❯ nebula-cert sign -name "nebula" -networks "192.168.1.1/24"
 Enter passphrase:
 # Entered my passphrase
@@ -75,7 +75,7 @@ allows you to move from v1 to v2 seamlessly. v1 does not support IPv6 though, so
 
 Using `nebula-cert show` we can see that the certificate has both cert format versions:
 
-```go
+```bash
 ❯ nebula-cert print -path nebula.crt
 {
         "details": {
@@ -139,11 +139,11 @@ Now that every host on the network is communicating via v2 certificates, you can
 the certificates. Pass `-version 2` to only create certificates in the v2 certificate format. This will enable the non
 backwards compatible features of the v2 certificates.
 
-```go
+```bash
 ❯ nebula-cert sign -name "nebula" -networks "192.168.1.1/24" -version 2
 ```
 
-```go
+```bash
 ❯ nebula-cert print -path nebula.crt
 {
         "curve": "CURVE25519",
@@ -168,11 +168,11 @@ backwards compatible features of the v2 certificates.
 
 You can also add an IPv6 address to your hosts now.
 
-```go
+```bash
 ❯ nebula-cert sign -name "nebula" -networks "192.168.1.1/24,fd0:0:0::1/64" -version 2
 ```
 
-```go
+```bash
 ❯ nebula-cert print -path nebula.crt
 {
         "curve": "CURVE25519",

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -1,147 +1,161 @@
 ---
-title: Upgrading to IPv6 support
+title: Upgrading a Nebula network to IPv6 overlay addresses
 summary:
-  This guide describes how to take an existing nebula network and upgrade it to use the new v2 certificates and enable
-  IPv6 addresses.
+  This guide describes how to upgrade an existing nebula network to the v2 certificate format and enable IPv6 addresses.
 ---
 
-# Upgrading to IPv6 support
+# Upgrading a Nebula network to IPv6 overlay addresses
 
-With newly added IPv6 support to nebula, there are a few steps that must be taken to enable it across your network.
+The upcoming release of Nebula (tenatively v1.10) will add support for IPv6-addressed Nebula hosts. To support the
+feature, Nebula has upgraded to a v2 certificate format. While v1 certificates support only a single IPv4 address for a
+given host, the v2 format allows multiple IPv4 and/or IPv6 addresses. In this guide we will describe how to upgrade a
+network to the v2 certificate format with IPv6 support.
 
-The basic steps go:
+Since Nebula v1.10 has yet to be released, we will first need to update every host on the network with a nightly build
+of Nebula. Next, we will issue backwards-compatible v1+v2 certificate bundles to each host. After updating each host's
+config with the new certificate bundle we will take a careful approach to switching over to the v2 certificate.
+
+The basic steps are:
 
 import TOCInline from '@theme/TOCInline';
 
 <TOCInline toc={toc} />
 
-## Upgrade to nebula nightly
+## Upgrade Nebula
 
-First, download the updated nebula version that has v2 certs and IPv6 support from nightly releases, and move all the
-hosts in your network to it.
+First, update each host in your network to a nightly build of Nebula with support for v2 certificates.
 
 - [https://github.com/NebulaOSS/nebula-nightly/releases](https://github.com/NebulaOSS/nebula-nightly/releases)
 - [https://hub.docker.com/r/nebulaoss/nebula-nightly](https://hub.docker.com/r/nebulaoss/nebula-nightly)
 
-## Add a v2 Certificate Authority
+## Create a v2 Certificate Authority
 
-Next, create a new CA for your network, and add it to the trust bundle of every host on the network. Creating a new CA
-with the nightly version of nebula will create a v2 CA by default, with support for creating and signing both v1 and v2
+Next, create a v2 Certificate Authority and add it to the trust bundle of every host on the network. Creating a new CA
+with the nightly version of Nebula will create a v2 CA by default. v2 CAs support creating and signing both v1 and v2
 certificates.
 
 ```bash
-❯ nebula-cert ca -name "Nebula IPv6 Tutorial CA" -encrypt
+❯ nebula-cert ca -name "My Nebula CA" -encrypt
 Enter passphrase:
-# typed in my password and pressed enter.
 ```
 
-Using `nebula-cert print` we can see that this is a v2 certificate authority, with support for IPv6 addresses.
+Using `nebula-cert print` we can see that this is a v2 certificate authority.
 
 ```bash
 ❯ nebula-cert print -path ./ca.crt
 {
-        "curve": "CURVE25519",
-        "details": {
-                "groups": null,
-                "isCa": true,
-                "issuer": "",
-                "name": "Nebula IPv6 Tutorial CA",
-                "networks": null,
-                "notAfter": "2026-03-11T12:26:19-05:00",
-                "notBefore": "2025-03-11T12:26:19-05:00",
-                "unsafeNetworks": null
-        },
-        "fingerprint": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
-        "publicKey": "4f1200baedc57f39adfc71e1b5409a3a7dc60fab4e1a2c4decaeb347a2ad4d75",
-        "signature": "e46d1f31e4b677fc4bbef9ebcf941261cd49e00fd4bf124e26b9fb7716d23e7588b0b6b87d276e625b30ef6fa32ced0aa46abee7b61d150907007586cd6e2203",
-        "version": 2
+	"curve": "CURVE25519",
+	"details": {
+		"groups": null,
+		"isCa": true,
+		"issuer": "",
+		"name": "My Nebula CA",
+		"networks": null,
+		"notAfter": "2026-04-01T17:02:36-04:00",
+		"notBefore": "2025-04-01T17:02:36-04:00",
+		"unsafeNetworks": null
+	},
+	"fingerprint": "62aabc872783f1036c7075fa49302c306baa1efb2afe9966f08401f157b6ae75",
+	"publicKey": "08edff75a4c83418ecac57f3c6f4c54d7a379c095c6fed161e947b471c5d63d8",
+	"signature": "6b5cf89afca09f5136f1fd6dd8edea9bf0a92f369e03fa54ec3b9ac75292aa367fdd7940d220f0ceae545e00ff93ccbac7dacf1c642c017c72f7ea4b38723205",
+	"version": 2
 }
 ```
 
-Copy the public key of the CA and add it to the `pki.ca` list in the config for every nebula host:
-[https://nebula.defined.net/docs/config/pki/#pkica](https://nebula.defined.net/docs/config/pki/#pkica)
+Append the new CA certificate to the [`pki.ca` trust bundle](https://nebula.defined.net/docs/config/pki/#pkica) in the
+config of every Nebula host and reload Nebula.
 
-## Re-issue v1+v2 certificates for every host with the v2 CA
+## Issue v1+v2 certificates bundles
 
-In order to move to a network where every host has ipv4 and ipv6, or every host has ipv6 only, it's recommended to start
-by re-issuing all hosts certificates with both v1 and v2 certificates for compatibility. Hosts will continue handshaking
-via the v1 cert while the network is being upgraded.
+Once the trust bundle of all hosts has been updated, we will issue v1+v2 certificate bundles using the new CA. We'll
+configure hosts with both certificates, but continue to use the v1 certificate for now.
 
-You can create a new v1+v2 cert like this:
+By default, nebula-cert will create both v1 and v2 versions of the certificate when creating and signing a certificate.
 
 ```bash
-❯ nebula-cert sign -name "nebula" -networks "192.168.1.1/24"
+❯ nebula-cert sign -name "host-1" -networks "192.168.1.1/24"
 Enter passphrase:
 # Entered my passphrase
 ```
 
-By default, nebula-cert will create a v1 and v2 version of the certificate when creating and signing a certificate. This
-allows you to move from v1 to v2 seamlessly. v1 does not support IPv6 though, so we'll move to only v2 soon.
-
-Using `nebula-cert show` we can see that the certificate has both cert format versions:
+Using `nebula-cert print` we can see that the file contains both versions of the certificate:
 
 ```bash
 ❯ nebula-cert print -path nebula.crt
 {
-        "details": {
-                "curve": "CURVE25519",
-                "groups": [],
-                "isCa": false,
-                "issuer": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
-                "name": "nebula",
-                "networks": [
-                        "192.168.1.1/24"
-                ],
-                "notAfter": "2026-03-11T12:26:18-05:00",
-                "notBefore": "2025-03-17T14:27:25-05:00",
-                "publicKey": "ba79878d86c88b8d679e2db2382a31f32177d5a27727a167ee94f8ef1e12793b",
-                "unsafeNetworks": []
-        },
-        "fingerprint": "c2292774eaadf83a0a25a051cb0c66a22df56733b8683104b317978547e99cbc",
-        "signature": "064c25cd0d2fe4db2af84c2cd9396053f200e79736c13fcf8abfc2458cb9f40be0a9563c5d05b0192b891ab48aec3a9d82a09527fda8632e6286546170e2700b",
-        "version": 1
+	"details": {
+		"curve": "CURVE25519",
+		"groups": [],
+		"isCa": false,
+		"issuer": "62aabc872783f1036c7075fa49302c306baa1efb2afe9966f08401f157b6ae75",
+		"name": "host-1",
+		"networks": [
+			"192.168.1.1/24"
+		],
+		"notAfter": "2026-04-01T17:02:35-04:00",
+		"notBefore": "2025-04-01T17:08:37-04:00",
+		"publicKey": "d368c3db5290f603c1f8456278b36d7854d49abfa183fb0d0e75b067c1b65d18",
+		"unsafeNetworks": []
+	},
+	"fingerprint": "e8b9a645bd09a472ddb66efa01ce871b40008f4299b1c82d78d5c0a806c5272a",
+	"signature": "6530d35de280f80a7d5c12657c6a31438d984588d0a107e053be86812da3dacdf6e4f83106dc3ecdd4cb1a6a325cefb4ae8dac61b5c95af85bd41d5574996b08",
+	"version": 1
 }
 {
-        "curve": "CURVE25519",
-        "details": {
-                "groups": null,
-                "isCa": false,
-                "issuer": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
-                "name": "nebula",
-                "networks": [
-                        "192.168.1.1/24"
-                ],
-                "notAfter": "2026-03-11T12:26:18-05:00",
-                "notBefore": "2025-03-17T14:27:25-05:00",
-                "unsafeNetworks": null
-        },
-        "fingerprint": "beef1fd9ea8a78164c53a83f5b3fb362dc1afa4c90ffb5db78c794be64286eca",
-        "publicKey": "ba79878d86c88b8d679e2db2382a31f32177d5a27727a167ee94f8ef1e12793b",
-        "signature": "8ae8314e87a2a8c6c85eb567b1db74f706dca74b9d748ee32f1c7b2ca6ad84946242bcf38c02b2a83a5109f07f4874bf84a331278ad21400c781c874ef392304",
-        "version": 2
+	"curve": "CURVE25519",
+	"details": {
+		"groups": null,
+		"isCa": false,
+		"issuer": "62aabc872783f1036c7075fa49302c306baa1efb2afe9966f08401f157b6ae75",
+		"name": "host-1",
+		"networks": [
+			"192.168.1.1/24"
+		],
+		"notAfter": "2026-04-01T17:02:35-04:00",
+		"notBefore": "2025-04-01T17:08:37-04:00",
+		"unsafeNetworks": null
+	},
+	"fingerprint": "e93af78e6c24340d260fcf8127b3138f45c93963572423d1931faca11bf68b85",
+	"publicKey": "d368c3db5290f603c1f8456278b36d7854d49abfa183fb0d0e75b067c1b65d18",
+	"signature": "21863ad3d8b62779f80ea3ef9ae4d85bf6a8f557c6c272eefda0962cd856a3625a088e08e209d200f2fae0087ff095377622b3ac09bba5d9c7a2c1d03baef00b",
+	"version": 2
 }
 ```
 
-## Move all hosts to only contain v2 certificates
+Update the corresponding [`pki.cert` field](https://nebula.defined.net/docs/config/pki/#pkicert) with the contents of
+the entire file, and **restart** Nebula. Nebula will continue to use the v1 certificate when initiating tunnels until
+we update the `pki.default_version` config option. When another host initiates a tunnel, Nebula will respond with the
+same certificate version it was presented.
 
-Removing the v1 certificates allows non-backwards compatible features to be enabled in your nebula network, like IPv6
-and multiple IPv4 and IPv6 network subnets contained within a network overlay.
+:::note
 
-The first step is to keep v1 certs on your hosts as backup, but to initiate tunnels with their v2 certs by default.
-Turning this setting on in steps allows you to detect issues with your config and reduce downtime in the case of a
-misconfig.
+When adding or removing either a v1 or v2 certificate from the `pki.cert` field, Nebula must be restarted. A reload is
+insufficient for this change.
 
-What follows is a suggested order of operations, but the general goal is to slowly roll out these changes, starting with
-the hosts that you don't expect to be initiating tunnels. We leave the lighthouses for last, since they're the
-coordinating nodes, and hosts still on v1 only will not be able to communicate with the network with their lighthouse is
-on v2 only. For a small network, it may be fine to simply change everything over in one go!
+:::
 
-After each step, you may validate that your changes have taken effect by using the `print-tunnel` command within the
-[debug ssh server](/docs/guides/debug-ssh-commands/).
+## Start handshaking with v2 certificates
 
-For example, when debugging `nebula(192.168.1.1)`'s tunnel to `lighthouse1(192.168.1.2)` where both have both v1 and v2
-certs and `pki.default_version` is set to `1` on both hosts, we can see that the certificate used in the tunnel is
-version 1.
+Once all hosts are configured with a v1+v2 certificate bundle, we can switch over to handshaking with the v2
+certificate. To do this, we set the `pki.default_version` config option to 2.
+
+We recommend slow rolling this change by starting with a small subset of hosts and verifying the change before rolling
+it out widely. After updating the config option, reloading Nebula, and establishing a tunnel you can verify the v2
+certificate is in use via the  `print-tunnel` command from [debug SSH server](/docs/guides/debug-ssh-commands/).
+
+In this example we've updated host-1 (192.168.1.1) with `pki.default_version` set to 2 and restarted Nebula. Since its
+default version is set to 2, it'll use the v2 certificate when handshaking with the Lighthouse. Because the Lighthouse
+has a v1+v2 bundle configured it is able to complete the connection, even though its `pki.default_version` is still set
+to 1.
+
+:::note
+
+If the Lighthouse were configured with only a v1 certificate, host-1 would not be able to connect, even though it has
+a v1+v2 certificate bundle configured. This is because `pki.default_version` indicates the certificate version that
+should be used in outgoing handshakes. If the receiving end does not support v2 certificates, the initiator will not
+fallback on a v1 certificate.
+
+:::
 
 ```bash
 steve@nebula > print-tunnel 192.168.1.2
@@ -171,7 +185,7 @@ steve@nebula > print-tunnel 192.168.1.2
     },
     "fingerprint": "84cf960de2e49f7560a5c7f876857528f02ab201c906f5a094d0d3294732b655",
     "signature": "6b9e98e398fb4c6a89f8e71e6a1378cecb85c500966443673a3ebe8f9d46702d0213dbd4c5028644104eeae49c06a4906058b53cd809e07dec76fcec60a4370d",
-    "version": 1
+    "version": 2
   },
   "messageCounter": 3,
   "currentRemote": "172.17.0.3:4242",
@@ -182,98 +196,72 @@ steve@nebula > print-tunnel 192.168.1.2
 
 You may also look in the host logs for the `certVersion` field in handshakes, ex:
 
-```perl
-time="2025-03-27T16:50:26-05:00" level=info msg="Handshake message received" certName=lighthouse1 certVersion=1 durationNs=63460958 fingerprint=84cf960de2e49f7560a5c7f876857528f02ab201c906f5a094d0d3294732b655 handshake="map[stage:2 style:ix_psk0]" initiatorIndex=530355834 issuer=a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c remoteIndex=530355834 responderIndex=3163624101 sentCachedPackets=1 udpAddr="172.17.0.3:4242" vpnAddrs="[192.168.1.2]"
+```bash
+time="2025-03-27T16:50:26-05:00" level=info msg="Handshake message received" certName=lighthouse1 certVersion=2 durationNs=63460958 fingerprint=84cf960de2e49f7560a5c7f876857528f02ab201c906f5a094d0d3294732b655 handshake="map[stage:2 style:ix_psk0]" initiatorIndex=530355834 issuer=a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c remoteIndex=530355834 responderIndex=3163624101 sentCachedPackets=1 udpAddr="172.17.0.3:4242" vpnAddrs="[192.168.1.2]"
 ```
 
-### Switch all non-lighthouse relays to use v2 certificates
-
-Switch all `am_relay: true && am_lighthouse: false` hosts' `pki.default_version` to `2` or add it if it doesn't exist
-yet.
-
-Now, if a relay initiates a handshake, it will attempt to use a v2 cert first, but this is an uncommon flow.
-
-Try [ssh debugging](/docs/guides/debug-ssh-commands/) with `print-tunnel` now to validate these hosts initiate their
-tunnels with v2 certificates.
-
-### Switch all non-lighthouse hosts to use v2 certificates
-
-Switch all `am_lighthouse: false` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet. Lighthouses
-will reply to v2 hosts using v2 protocols.
-
-Try [ssh debugging](/docs/guides/debug-ssh-commands/) with `print-tunnel` now to validate these hosts initiate their
-tunnels with v2 certificates.
-
-### Switch all lighthouses to use v2 certificates
-
-Switch all `am_lighthouse: true` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet. Now all of your
-hosts should be using their v2 certificate for initiating tunnels.
-
-Try [ssh debugging](/docs/guides/debug-ssh-commands/) with `print-tunnel` now to validate these hosts initiate their
-tunnels with v2 certificates.
-
-## Re-issue v2 certificates for the hosts
+## Remove v1 certificates from hosts
 
 Now that every host on the network is communicating via v2 certificates, you can remove the v1 certificates by reissuing
-the certificates. Pass `-version 2` to only create certificates in the v2 certificate format. This will enable the non
-backwards compatible features of the v2 certificates.
+the certificates. Pass `-version 2` to only create certificates in the v2 certificate format.
 
 ```bash
-❯ nebula-cert sign -name "nebula" -networks "192.168.1.1/24" -version 2
+❯ nebula-cert sign -name "host-1" -networks "192.168.1.1/24" -version 2
 ```
 
 ```bash
-❯ nebula-cert print -path nebula.crt
+❯ nebula-cert print -path host-1.crt
 {
-        "curve": "CURVE25519",
-        "details": {
-                "groups": null,
-                "isCa": false,
-                "issuer": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
-                "name": "nebula",
-                "networks": [
-                        "192.168.1.1/24"
-                ],
-                "notAfter": "2026-03-11T12:26:18-05:00",
-                "notBefore": "2025-03-17T16:06:48-05:00",
-                "unsafeNetworks": null
-        },
-        "fingerprint": "7260e59ca62a6a23ef8c6d5e912790fcb7073ffa1fe5da485d934a99d558c5ab",
-        "publicKey": "05baa0d1af10b89a8336c925a5c9b5fda5599943ee53a5bc742a573aa3e2753d",
-        "signature": "275229cd09228312171450fecc696776745dab88f6686e2a2577b764e4829a6566e3821e1101cdedb035e649fa70dc634300b3e628bf8ea839b6215ff68fdf02",
-        "version": 2
+	"curve": "CURVE25519",
+	"details": {
+		"groups": null,
+		"isCa": false,
+		"issuer": "62aabc872783f1036c7075fa49302c306baa1efb2afe9966f08401f157b6ae75",
+		"name": "host-1",
+		"networks": [
+			"192.168.1.1/24"
+		],
+		"notAfter": "2026-04-01T17:02:35-04:00",
+		"notBefore": "2025-04-01T20:40:00-04:00",
+		"unsafeNetworks": null
+	},
+	"fingerprint": "05930841ba198874b932504de1cceb26e8d84b931ea29c673e22e0be06fb75f0",
+	"publicKey": "501410109bd531fc5af3c75019cd2ed8349abfb56e3299a30ff72773300d1a4a",
+	"signature": "fa1db2751fcbd6db73133364075f1577e17c3db4009bb84a7d82f159aaa4e17bb3b43636295567abda3ba9c9ad4cd5ed6357fffb8c93ebc299f3f8809e3aeb0e",
+	"version": 2
 }
 ```
 
-You can also add an IPv6 address to your hosts now.
+At this point, you may wish to assign an IPv6 address:
 
 ```bash
-❯ nebula-cert sign -name "nebula" -networks "192.168.1.1/24,fd0:0:0::1/64" -version 2
+❯ nebula-cert sign -name "host-1" -networks "192.168.1.1/24,fdc8:d0db:a315:cb00::1/64" -version 2
 ```
 
 ```bash
-❯ nebula-cert print -path nebula.crt
+❯ nebula-cert print -path host-1.crt
 {
-        "curve": "CURVE25519",
-        "details": {
-                "groups": null,
-                "isCa": false,
-                "issuer": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
-                "name": "nebula",
-                "networks": [
-                        "192.168.1.1/24",
-                        "fd0::1/64"
-                ],
-                "notAfter": "2026-03-11T12:26:18-05:00",
-                "notBefore": "2025-03-17T16:11:30-05:00",
-                "unsafeNetworks": null
-        },
-        "fingerprint": "08e9d282adb0809457ad63982a9f1113a462763da58aa69b76d2b4cb1cd24724",
-        "publicKey": "ae950d4d0db966f93b5f463c9910d3fe9efd69347ddec4f3ed0f379c51712e0f",
-        "signature": "d156b2cd48916377426d8fab3286d176590ea48b83853f44f92089f1fb6d6bca9727b7169d3640e8a3418b3eac74159cb4368d847bd346663249d2dbbd81670e",
-        "version": 2
+	"curve": "CURVE25519",
+	"details": {
+		"groups": null,
+		"isCa": false,
+		"issuer": "62aabc872783f1036c7075fa49302c306baa1efb2afe9966f08401f157b6ae75",
+		"name": "host-1",
+		"networks": [
+			"192.168.1.1/24",
+			"fdc8:d0db:a315:cb00::1/64"
+		],
+		"notAfter": "2026-04-01T17:02:35-04:00",
+		"notBefore": "2025-04-01T20:38:21-04:00",
+		"unsafeNetworks": null
+	},
+	"fingerprint": "2eda0f2dc5c5f8b097a09027fc896c9b6ba78d8fdac1559878caccd4c947e3ff",
+	"publicKey": "d8ebf7a93e62044eee4bc504aa2e82e80d79db11cfee37c75b3769df261d343b",
+	"signature": "5a5987e2e7e0e8619b0b111d951b3297f2c704387a032f84876172a3f1864e7fb2a5bf2ce48f3fa48ff6f60d39749ba3444b073485f6a9d41c6d3c9d7856f104",
+	"version": 2
 }
 ```
 
 Once you switch services over to use the new IPv6 addresses, you can decide to deprecate the IPv4 addresses or continue
-to run your overlay network with both IPv4 and IPv6 subnets.
+to run your overlay network with both IPv4 and IPv6 subnets. If you decide to switch to IPv6-only, don't forget to
+update your `static_host_map`.

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -187,15 +187,24 @@ yet.
 
 Now, if a relay initiates a handshake, it will attempt to use a v2 cert first, but this is an uncommon flow.
 
+Try [ssh debugging](/docs/guides/debug-ssh-commands/) with `print-tunnel` now to validate these hosts initiate their
+tunnels with v2 certificates.
+
 ### Switch all non-lighthouse hosts to use v2 certificates
 
 Switch all `am_lighthouse: false` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet. Lighthouses
 will reply to v2 hosts using v2 protocols.
 
+Try [ssh debugging](/docs/guides/debug-ssh-commands/) with `print-tunnel` now to validate these hosts initiate their
+tunnels with v2 certificates.
+
 ### Switch all lighthouses to use v2 certificates
 
 Switch all `am_lighthouse: true` hosts' `pki.default_version` to `2` or add it if it doesn't exist yet. Now all of your
 hosts should be using their v2 certificate for initiating tunnels.
+
+Try [ssh debugging](/docs/guides/debug-ssh-commands/) with `print-tunnel` now to validate these hosts initiate their
+tunnels with v2 certificates.
 
 ## Re-issue v2 certificates for the hosts
 

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -144,7 +144,39 @@ For example, when debugging `nebula`'s tunnel to `lighthouse1` where both have b
 
 ```bash
 steve@nebula > print-tunnel 192.168.1.2
-{"vpnAddrs":["192.168.1.2"],"localIndex":2965094606,"remoteIndex":1285130098,"remoteAddrs":["172.17.0.3:4242"],"cert":{"details":{"curve":"CURVE25519","groups":[],"isCa":false,"issuer":"a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c","name":"lighthouse1","networks":["192.168.1.2/24"],"notAfter":"2026-03-11T17:26:18Z","notBefore":"2025-03-18T17:14:43Z","publicKey":"c455bc023b1b3918538edf5f230169df12603703639db158c76da747e0eccc47","unsafeNetworks":[]},"fingerprint":"84cf960de2e49f7560a5c7f876857528f02ab201c906f5a094d0d3294732b655","signature":"6b9e98e398fb4c6a89f8e71e6a1378cecb85c500966443673a3ebe8f9d46702d0213dbd4c5028644104eeae49c06a4906058b53cd809e07dec76fcec60a4370d","version":1},"messageCounter":3,"currentRemote":"172.17.0.3:4242","currentRelaysToMe":[],"currentRelaysThroughMe":[]}
+{
+  "vpnAddrs": [
+    "192.168.1.2"
+  ],
+  "localIndex": 2965094606,
+  "remoteIndex": 1285130098,
+  "remoteAddrs": [
+    "172.17.0.3:4242"
+  ],
+  "cert": {
+    "details": {
+      "curve": "CURVE25519",
+      "groups": [],
+      "isCa": false,
+      "issuer": "a95ed86f7754fc5b0fcaf38473504403748d6dc422b16bc3e29fcae32af9a73c",
+      "name": "lighthouse1",
+      "networks": [
+        "192.168.1.2/24"
+      ],
+      "notAfter": "2026-03-11T17:26:18Z",
+      "notBefore": "2025-03-18T17:14:43Z",
+      "publicKey": "c455bc023b1b3918538edf5f230169df12603703639db158c76da747e0eccc47",
+      "unsafeNetworks": []
+    },
+    "fingerprint": "84cf960de2e49f7560a5c7f876857528f02ab201c906f5a094d0d3294732b655",
+    "signature": "6b9e98e398fb4c6a89f8e71e6a1378cecb85c500966443673a3ebe8f9d46702d0213dbd4c5028644104eeae49c06a4906058b53cd809e07dec76fcec60a4370d",
+    "version": 1
+  },
+  "messageCounter": 3,
+  "currentRemote": "172.17.0.3:4242",
+  "currentRelaysToMe": [],
+  "currentRelaysThroughMe": []
+}
 ```
 
 ### Switch all non-lighthouse relays to use v2 certificates

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -58,7 +58,7 @@ Using `nebula-cert print` we can see that this is a v2 certificate authority, wi
 }
 ```
 
-Add the public key of the CA to the `pki.ca` list in the config for every nebula host:
+Copy the public key of the CA and add it to the `pki.ca` list in the config for every nebula host:
 [https://nebula.defined.net/docs/config/pki/#pkica](https://nebula.defined.net/docs/config/pki/#pkica)
 
 ## Re-issue v1+v2 certificates for every host with the v2 CA

--- a/docusaurus.config.cjs
+++ b/docusaurus.config.cjs
@@ -149,6 +149,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['bash'],
       },
     },
 };


### PR DESCRIPTION
Hopefully this is a good starter for folks trying to upgrade their network.

Deploy Preview: https://deploy-preview-223--nebula-docs-dn.netlify.app/docs/guides/upgrade-to-cert-v2-and-ipv6/

- [ ] Validate loading a v1cert from a v2 CA on a pre-v2cert nebula install, possibly recommend that v1 certs are signed by v1 ca's and v2 certs are signed by v2 ca's.