### PR TITLE
Re-add the nebula.defined.net google analytics

### DIFF
--- a/docusaurus.config.cjs
+++ b/docusaurus.config.cjs
@@ -6,6 +6,22 @@ const darkCodeTheme = require('./src/prism-dark.cjs');
 const lightCodeTheme = require('./src/prism-light.cjs');
 const hq = require('alias-hq');
 
+let gtag;
+
+// Only enable google analytics in prod.  Note: this is a CF Workers environment variable.
+if (process.env.GTAG_TRACKING_ID) {
+  /* eslint-disable-next-line no-console -- Allow build config to log what's happening */
+  console.log('Google Analytics enabled');
+  gtag = {
+    trackingID: process.env.GTAG_TRACKING_ID,
+    anonymizeIP: true,
+  };
+} else {
+  /* eslint-disable-next-line no-console -- Allow build config to log what's happening */
+  console.log('Google Analytics disabled');
+  gtag = undefined;
+}
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Nebula Docs',
@@ -52,6 +68,7 @@ const config = {
             require.resolve('./src/css/utility.css'),
           ],
         },
+        gtag,
       }),
     ],
   ],


### PR DESCRIPTION
This enables https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag, built-in to the docusaurus classic preset. It looks for the `GTAG_TRACKING_ID` that we only set in the production CF env.

<img width="780" height="206" alt="image" src="https://github.com/user-attachments/assets/bc7ec972-542d-4640-8ce8-d55e181997a5" />
