### PR TITLE
Fix dependabot react regex to match react and react-dom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
           - '@docusaurus/*'
       react-dependencies:
         patterns:
-          - 'react-*'
+          - 'react*'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
#298 and https://github.com/DefinedNet/nebula-docs/pull/284 are separately open when they need to be bumped together.

Moved from `react-*` for react package grouping to `react*` to match both "react" and "react-dom"