### PR TITLE
Document pki.initiating_version configuration

### DIFF
--- a/docs/config/pki.mdx
+++ b/docs/config/pki.mdx
@@ -86,7 +86,9 @@ stolen or compromised.
 
 <Pill className="mb-24">Default: 0</Pill>
 
-`pki.initiating_version` determines which nebula cert version to use when initiating new connections. If unset (or set
-to 0), it will default to v1 if any v1 cert is available, otherwise it will default to v2.
+`pki.initiating_version` determines which nebula cert version to use when initiating new connections. This setting only
+applies if both a v1 and a v2 certificate are configured, in which case it will default to `1`. Once all hosts in the
+mesh are configured with both a v1 and v2 certificate then this will default to `2`. After all hosts in the mesh are
+using a v2 certificate then v1 certificates are no longer needed.
 
 Added in Nebula v1.10.0


### PR DESCRIPTION
Add documentation for pki.initiating_version and its default behavior.

Fixes https://github.com/DefinedNet/nebula-docs/issues/222

Is there other new config in v1.10? IDK.