### PR TITLE
Remove unused netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,0 @@
-[[redirects]]
-  from = "/"
-  to = "/docs/"
-  force = true
-
-[dev]
-  framework = "docusaurus-v2"


### PR DESCRIPTION
We deploy via Cloudflare now, we don't need the Netlify config.