### PR TITLE
Improve SEO: add meta descriptions, robots.txt, and site metadata

### DIFF
--- a/docs/config/_category_.json
+++ b/docs/config/_category_.json
@@ -3,7 +3,7 @@
   "position": 4,
   "link": {
     "type": "generated-index",
-    "description": "Configuration options for Nebula.",
+    "description": "Complete reference for all Nebula configuration options including PKI, firewall rules, lighthouse, relay, tun, and more.",
     "slug": "/config"
   }
 }

--- a/docs/guides/_category_.json
+++ b/docs/guides/_category_.json
@@ -3,7 +3,7 @@
   "position": 2,
   "link": {
     "type": "generated-index",
-    "description": "A collection of how-to guides that explain how to use various capabilities of the Nebula overlay networking tool.",
+    "description": "Step-by-step guides for configuring and troubleshooting Nebula overlay networks, including quick start, certificate management, DNS, and routing.",
     "slug": "/guides"
   }
 }

--- a/docs/guides/debug-ssh-commands/index.mdx
+++ b/docs/guides/debug-ssh-commands/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Debugging with Nebula SSH commands
-description: Learn how to use Nebula's built-in SSH server commands to debug network connectivity issues on overlay hosts.
+description:
+  Learn how to use Nebula's built-in SSH server commands to debug network connectivity issues on overlay hosts.
 summary:
   This guide describes useful commands built into the SSH server accessible over nebula, which can allow debugging
   network connectivity for the nebula host.

--- a/docs/guides/debug-ssh-commands/index.mdx
+++ b/docs/guides/debug-ssh-commands/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Debugging with Nebula SSH commands
+description: Learn how to use Nebula's built-in SSH server commands to debug network connectivity issues on overlay hosts.
 summary:
   This guide describes useful commands built into the SSH server accessible over nebula, which can allow debugging
   network connectivity for the nebula host.

--- a/docs/guides/quick-start/index.mdx
+++ b/docs/guides/quick-start/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Quick Start
-description:
-  'Nebula Docs: How to create your first overlay network using a Certificate Authority, Lighthouse, and Hosts'
+description: How to create your first overlay network using a Certificate Authority, Lighthouse, and Hosts
 summary:
   This section will walk you through setting up a simple nebula network for testing. The examples will need to be
   modified to suit your particular environment.

--- a/docs/guides/rotating-certificate-authority/index.mdx
+++ b/docs/guides/rotating-certificate-authority/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rotating a Certificate Authority
-description: 'Nebula Docs: How to rotate an expiring certificate authority without downtime.'
+description: How to rotate an expiring Nebula certificate authority without downtime.
 summary:
   This guide will teach you how to migrate from an expiring certificate authority by creating a new certificate
   authority, updating your device's Nebula config to trust the new authority, signing new host certificates, and

--- a/docs/guides/sign-certificates-with-public-keys/index.mdx
+++ b/docs/guides/sign-certificates-with-public-keys/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Signing a Certificate Without a Private Key
-description: 'Nebula Docs: How to sign certificates without copying private keys across devices.'
+description: How to sign Nebula certificates without copying private keys across devices.
 summary:
   After reading this guide you will be able to create public/private keypairs on devices you wish to add to the Nebula
   network and generate certificates for them using only the public key.

--- a/docs/guides/unsafe_routes/index.mdx
+++ b/docs/guides/unsafe_routes/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Extend network access beyond overlay hosts
+description: Configure Nebula unsafe_routes to route traffic through overlay hosts and reach devices that cannot run Nebula directly.
 summary:
   This guide explains how to configure Nebula to route traffic destined for a specific subnet through a specific overlay
   network host, which is useful for accessing hosts that cannot be modified to run Nebula.

--- a/docs/guides/unsafe_routes/index.mdx
+++ b/docs/guides/unsafe_routes/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Extend network access beyond overlay hosts
-description: Configure Nebula unsafe_routes to route traffic through overlay hosts and reach devices that cannot run Nebula directly.
+description:
+  Configure Nebula unsafe_routes to route traffic through overlay hosts and reach devices that cannot run Nebula
+  directly.
 summary:
   This guide explains how to configure Nebula to route traffic destined for a specific subnet through a specific overlay
   network host, which is useful for accessing hosts that cannot be modified to run Nebula.

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Upgrading a Nebula network to IPv6 overlay addresses
-description: Step-by-step guide to upgrading an existing Nebula network to the v2 certificate format and enabling IPv6 overlay addresses.
+description:
+  Step-by-step guide to upgrading an existing Nebula network to the v2 certificate format and enabling IPv6 overlay
+  addresses.
 summary:
   This guide describes how to upgrade an existing nebula network to the v2 certificate format and enable IPv6 addresses.
 ---

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Upgrading a Nebula network to IPv6 overlay addresses
+description: Step-by-step guide to upgrading an existing Nebula network to the v2 certificate format and enabling IPv6 overlay addresses.
 summary:
   This guide describes how to upgrade an existing nebula network to the v2 certificate format and enable IPv6 addresses.
 ---

--- a/docs/guides/using-lighthouse-dns/index.mdx
+++ b/docs/guides/using-lighthouse-dns/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Using Lighthouse DNS with Nebula
-description: Configure Nebula's experimental built-in DNS server on Lighthouse hosts to resolve overlay network hostnames.
+description:
+  Configure Nebula's experimental built-in DNS server on Lighthouse hosts to resolve overlay network hostnames.
 ---
 
 # Using Experimental Lighthouse DNS with Nebula

--- a/docs/guides/using-lighthouse-dns/index.mdx
+++ b/docs/guides/using-lighthouse-dns/index.mdx
@@ -1,3 +1,8 @@
+---
+title: Using Lighthouse DNS with Nebula
+description: Configure Nebula's experimental built-in DNS server on Lighthouse hosts to resolve overlay network hostnames.
+---
+
 # Using Experimental Lighthouse DNS with Nebula
 
 :::warning

--- a/docs/guides/viewing-nebula-logs/index.mdx
+++ b/docs/guides/viewing-nebula-logs/index.mdx
@@ -1,3 +1,8 @@
+---
+title: Viewing Nebula Logs
+description: How to view Nebula logs on Linux, macOS, Windows, iOS, and Android for troubleshooting and monitoring.
+---
+
 import ThemedImage from '@theme/ThemedImage';
 
 # Viewing Nebula Logs

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,8 @@
 ---
 title: Introduction to Nebula
-description: Nebula is an open source overlay networking tool for building fast, secure, and scalable networks. Connect hosts with encrypted tunnels across any IP network.
+description:
+  Nebula is an open source overlay networking tool for building fast, secure, and scalable networks. Connect hosts with
+  encrypted tunnels across any IP network.
 slug: /
 sidebar_position: 1
 ---

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Nebula
+description: Nebula is an open source overlay networking tool for building fast, secure, and scalable networks. Connect hosts with encrypted tunnels across any IP network.
 slug: /
 sidebar_position: 1
 ---

--- a/docs/security/_category_.json
+++ b/docs/security/_category_.json
@@ -3,7 +3,7 @@
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "Security bulletins for Nebula.",
+    "description": "Security advisories and vulnerability disclosures for the Nebula overlay networking tool.",
     "slug": "/security"
   }
 }

--- a/docs/security/_category_.json
+++ b/docs/security/_category_.json
@@ -3,7 +3,7 @@
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "Security advisories and vulnerability disclosures for the Nebula overlay networking tool.",
+    "description": "Security bulletins for the Nebula overlay networking tool.",
     "slug": "/security"
   }
 }

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -164,7 +164,7 @@ const config: Config = {
       contextualSearch: false,
 
       // Optional: path for search page that enabled by default (`false` to disable it)
-      searchPagePath: 'false',
+      searchPagePath: false,
     },
     prism: {
       theme: lightCodeTheme,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -22,7 +22,7 @@ if (process.env.GTAG_TRACKING_ID) {
 
 const config: Config = {
   title: 'Nebula Docs',
-  tagline: 'Learn about Nebula here',
+  tagline: 'Documentation for Nebula, an open source overlay networking tool',
   url: 'https://nebula.defined.net',
   // For deploy previews, don't set a baseUrl
   baseUrl: '/',
@@ -79,8 +79,9 @@ const config: Config = {
 
   themeConfig: {
     image: 'img/nebula-docs-og.png',
+    metadata: [{ name: 'keywords', content: 'nebula, overlay network, VPN, mesh networking, defined networking' }],
     navbar: {
-      title: '',
+      title: 'Nebula Docs',
       logo: {
         alt: 'Nebula logo',
         href: '/docs/',
@@ -163,7 +164,7 @@ const config: Config = {
       contextualSearch: false,
 
       // Optional: path for search page that enabled by default (`false` to disable it)
-      searchPagePath: false,
+      searchPagePath: 'search',
     },
     prism: {
       theme: lightCodeTheme,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -81,7 +81,7 @@ const config: Config = {
     image: 'img/nebula-docs-og.png',
     metadata: [{ name: 'keywords', content: 'nebula, overlay network, VPN, mesh networking, defined networking' }],
     navbar: {
-      title: 'Nebula Docs',
+      title: 'Nebula Documentation',
       logo: {
         alt: 'Nebula logo',
         href: '/docs/',
@@ -164,7 +164,7 @@ const config: Config = {
       contextualSearch: false,
 
       // Optional: path for search page that enabled by default (`false` to disable it)
-      searchPagePath: 'search',
+      searchPagePath: 'false',
     },
     prism: {
       theme: lightCodeTheme,

--- a/src/css/utility.css
+++ b/src/css/utility.css
@@ -1,3 +1,7 @@
 .mb-24 {
   margin-bottom: 24px;
 }
+
+.navbar__title {
+  display: none;
+}

--- a/src/css/utility.css
+++ b/src/css/utility.css
@@ -2,6 +2,8 @@
   margin-bottom: 24px;
 }
 
+/* Hide navbar title visually while keeping it in the DOM for crawlers */
+
 .navbar__title {
   display: none;
 }

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://nebula.defined.net/sitemap.xml


### PR DESCRIPTION
## Summary
- Add missing meta descriptions to the landing page and 5 guide pages that had none
- Remove redundant "Nebula Docs:" prefix from 3 guide descriptions to maximize SERP snippet space
- Add `robots.txt` with sitemap reference
- Enrich thin category index descriptions (config, guides, security)
- Update `docusaurus.config.ts`: better tagline, site-wide keywords meta tag, navbar title for crawlability (visually hidden)
- Add frontmatter blocks to 2 guide pages that had no frontmatter at all