### PR TITLE
Add host discovery guide (static_host_map vs advertise_addrs)

### DIFF
--- a/docs/config/lighthouse.mdx
+++ b/docs/config/lighthouse.mdx
@@ -52,8 +52,8 @@ configured to be lighthouses in your network
 <Pill className="mb-24">Default: False</Pill>
 
 `serve_dns` optionally starts a DNS listener that responds to `A` and `TXT` queries and can even be delegated to for
-name resolution by external DNS hosts. To enable listening on IPv6 in addition to IPv4, set `lighthouse.dns.host` to
-`'[::]'`.
+name resolution by external DNS hosts. To enable listening on IPv6 in addition to IPv4, set
+[`lighthouse.dns.host`](#lighthousedns) to `'[::]'`.
 
 The DNS listener can only respond to requests about hosts it's aware of. For this reason, it can only be enabled on
 Lighthouses.
@@ -104,7 +104,7 @@ firewall:
 host's Nebula IP, you can make the DNS server accessible only on the Nebula network. Alternatively, listening on
 `0.0.0.0` will allow anyone that can reach the host to make queries.
 
-The default value for `dns.port` is `53` but you must set an IP address.
+The default value for [`lighthouse.dns.port`](#lighthousedns) is `53` but you must set an IP address.
 
 See the [`serve_dns`](#lighthouseserve_dns) docs for more information.
 
@@ -169,9 +169,10 @@ lighthouse:
 <Pill className="mb-24">Reloadable</Pill>
 
 `local_allow_list` allows you to filter which local IP addresses we advertise to the lighthouses. This uses the same
-logic as `remote_allow_list`, but additionally, you can specify an `interfaces` map of regular expressions to match
-against interface names. The regexp must match the entire name. All interface rules must be either true or false (and
-the default will be the inverse). CIDR rules are matched after interface name rules. Default is all local IP addresses.
+logic as [`lighthouse.remote_allow_list`](#lighthouseremote_allow_list), but additionally, you can specify an
+`interfaces` map of regular expressions to match against interface names. The regexp must match the entire name. All
+interface rules must be either true or false (and the default will be the inverse). CIDR rules are matched after
+interface name rules. Default is all local IP addresses.
 
 ```yml
 lighthouse:
@@ -190,9 +191,14 @@ lighthouse:
 
 `advertise_addrs` are routable addresses that will be included along with discovered addresses to report to the
 lighthouse. The format is "ip:port". `port` can be `0`, in which case the actual listening port will be used in its
-place, useful if `listen.port` is set to `0`. This option is mainly useful when there are static IP addresses the host
-can be reached at that nebula can not typically discover on its own (e.g. when port forwarding or when the node has
-multiple paths to the internet.)
+place, useful if [`listen.port`](/docs/config/listen/#listenport) is set to `0`. This option is mainly useful when there
+are static IP addresses the host can be reached at that nebula can not typically discover on its own (e.g. when port
+forwarding or when the node has multiple paths to the internet.)
+
+Unlike [`static_host_map`](/docs/config/static-host-map/) entries, which must be added to every peer's config,
+[`lighthouse.advertise_addrs`](#lighthouseadvertise_addrs) is set once on the host itself and propagates to peers
+through the lighthouses. See [How hosts find each other](/docs/guides/host-discovery/) for a comparison of the two
+mechanisms.
 
 ## lighthouse.calculated_remotes
 

--- a/docs/config/static-host-map.mdx
+++ b/docs/config/static-host-map.mdx
@@ -5,8 +5,15 @@ description: Define the static host map to enable peer discovery on the Nebula n
 
 # static_host_map
 
-The static host map defines a set of hosts with fixed IP addresses on the internet (or any network). A host can have
-multiple fixed IP addresses defined here, and nebula will try each when establishing a tunnel. The syntax is:
+The static host map defines a set of hosts with fixed IP addresses (or DNS names) on the internet (or any network).
+Entries listed here are dialed directly, without lighthouse mediation, which makes the static host map the bootstrap
+path for connectivity: it works before — and without — any lighthouse being reachable. Every host must have an entry for
+each [lighthouse](/docs/config/lighthouse/) in the network, because the discovery service itself cannot be discovered
+dynamically. See [How hosts find each other](/docs/guides/host-discovery/) for when to list other hosts here versus
+relying on lighthouse discovery or [`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs).
+
+A host can have multiple fixed IP addresses defined here, and nebula will try each when establishing a tunnel. The
+syntax is:
 
 `"<nebula ip>": ["<routable ip/dns name>:<routable port>"]`
 
@@ -17,3 +24,13 @@ port 4242:
 static_host_map:
   '192.168.100.1': ['100.64.22.11:4242']
 ```
+
+Entries may mix literal IPs, DNS names, and IPv6 addresses (bracketed):
+
+```yml
+static_host_map:
+  '192.168.100.1': ['100.64.22.11:4242', 'lighthouse.example.com:4242', '[2001:db8::1]:4242']
+```
+
+DNS names are re-resolved periodically; the [static_map](/docs/config/static-map/) settings control the resolution
+cadence, lookup timeout, and which IP version is used to reach static hosts.

--- a/docs/guides/debug-ssh-commands/index.mdx
+++ b/docs/guides/debug-ssh-commands/index.mdx
@@ -5,7 +5,7 @@ description:
 summary:
   This guide describes useful commands built into the SSH server accessible over nebula, which can allow debugging
   network connectivity for the nebula host.
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Debugging with Nebula SSH commands

--- a/docs/guides/host-discovery/index.mdx
+++ b/docs/guides/host-discovery/index.mdx
@@ -1,4 +1,5 @@
 ---
+sidebar_position: 2
 title: How Hosts Find Each Other
 description:
   The two mechanisms Nebula hosts use to discover each other's routable addresses — the static host map and lighthouse

--- a/docs/guides/host-discovery/index.mdx
+++ b/docs/guides/host-discovery/index.mdx
@@ -1,0 +1,151 @@
+---
+title: How Hosts Find Each Other
+description:
+  The two mechanisms Nebula hosts use to discover each other's routable addresses — the static host map and lighthouse
+  discovery — and when to use each.
+summary:
+  Every Nebula host has an overlay IP that is not routable on the internet. This guide explains the two mechanisms a
+  host uses to learn where a peer can actually be reached — static host map entries and lighthouse discovery — and how
+  to choose between them for each host in your network.
+---
+
+# How Hosts Find Each Other
+
+Every host in your network has a Nebula IP, but that address only exists inside the overlay. To establish a tunnel with
+a peer, a host needs the peer's _underlay_ address — a routable IP and port like `203.0.113.42:4242` — to send packets
+to. Host discovery is how a host learns that address.
+
+There are two ways a host can learn where to reach a peer:
+
+1. **The static path** — the peer is listed in the host's own [`static_host_map`](/docs/config/static-host-map/), so the
+   host dials the listed address directly.
+2. **The dynamic path** — the host asks a [lighthouse](/docs/config/lighthouse/), which keeps track of where every host
+   was last reachable.
+
+The two paths work together: static entries let hosts reach the lighthouses in the first place, and lighthouses handle
+everything that moves — laptops changing networks, hosts behind NATs, dynamic IPs.
+
+## The static path: `static_host_map`
+
+A static host map entry maps a peer's Nebula IP to one or more addresses where it can be dialed directly:
+
+```yml
+static_host_map:
+  '192.168.100.1': ['203.0.113.42:4242']
+  '192.168.100.5': ['server.example.com:4242', '[2001:db8::5]:4242']
+```
+
+When establishing a tunnel to one of these peers, nebula tries each listed address until a handshake succeeds. Entries
+can be literal IPv4 addresses, DNS names, or bracketed IPv6 literals, and a single host can list several — useful when a
+peer is reachable over multiple paths.
+
+Because the addresses come from local config, no lighthouse is involved: a statically mapped peer stays reachable even
+while every lighthouse is down. The cost is maintenance. An entry only helps hosts whose config contains it, so making
+one host statically reachable means editing every peer's config — and if the address changes and an entry goes stale,
+peers waste handshake attempts dialing it.
+
+DNS names in the static host map are re-resolved periodically, not just at startup. The
+[`static_map`](/docs/config/static-map/) settings control the re-resolution cadence, the lookup timeout, and which IP
+version is used — the default is IPv4-only, so IPv6-only hosts must set
+[`static_map.network`](/docs/config/static-map/#static_mapnetwork) to `ip6` or `ip`.
+
+## The dynamic path: lighthouse discovery
+
+Every host (except lighthouses themselves) reports to its lighthouses on a timer — every
+[`lighthouse.interval`](/docs/config/lighthouse/#lighthouseinterval) seconds, 10 by default:
+
+```yml
+lighthouse:
+  am_lighthouse: false
+  hosts:
+    - '192.168.100.1' # nebula IP of the lighthouse to report to
+```
+
+Each report carries the addresses the host knows about itself: the IPs on its local interfaces (filtered by
+[`lighthouse.local_allow_list`](/docs/config/lighthouse/#lighthouselocal_allow_list)) plus anything listed in
+[`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs).
+
+But a host behind a NAT doesn't know its own public address — so the lighthouse learns it another way: it looks at the
+source IP and port on the report packets as they arrive. That observed address is usually exactly what other peers need
+to dial to reach the host through its NAT, and it's why a NAT'd host becomes discoverable without configuring anything.
+
+When a host wants to handshake with a peer it has no static entry for, it asks its lighthouses where that peer was last
+seen, then tries the returned addresses (filtered by
+[`lighthouse.remote_allow_list`](/docs/config/lighthouse/#lighthouseremote_allow_list)).
+
+### When discovery needs help: `advertise_addrs`
+
+Sometimes neither self-inspection nor packet observation produces the right address. Common cases:
+
+- **Port forwarding** — your router forwards public port `5555` to the host's listening port `4242`; peers must dial
+  `:5555`, but the host only knows about `:4242`.
+- **Multiple paths to the internet** — only the path used to reach the lighthouse gets observed; the others are
+  invisible.
+
+[`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs) fixes this from the affected host's
+own config: the listed addresses ride along in its lighthouse reports and propagate to peers automatically — no other
+host's config changes.
+
+```yml
+lighthouse:
+  advertise_addrs:
+    - '203.0.113.42:5555' # the forwarded public port, not the local listening port
+```
+
+## Why lighthouses must be in every static host map
+
+A lighthouse is the discovery service — and you can't discover the discovery service. Before a host has talked to a
+lighthouse, the static host map is the only source of addresses it has, so every host's config must carry a static entry
+for every lighthouse:
+
+```yml
+static_host_map:
+  '192.168.100.1': ['203.0.113.42:4242'] # the lighthouse
+
+lighthouse:
+  am_lighthouse: false
+  hosts:
+    - '192.168.100.1' # matches the static entry above
+```
+
+Lighthouses themselves are on the receiving end of this arrangement: every host comes to them, so their own
+[`static_host_map`](/docs/config/static-host-map/) is typically empty, and multiple lighthouses generally don't need to
+know about each other.
+
+## Choosing for each host
+
+- **A lighthouse** — must have a fixed, routable address, listed in every other host's
+  [`static_host_map`](/docs/config/static-host-map/). This is not optional; it's what makes discovery work.
+- **A stable server** (fixed public IP or DNS name) — works fine with dynamic discovery alone, but adding it to peers'
+  static host maps means those peers can reach it directly and keep reaching it during a lighthouse outage. Weigh that
+  against maintaining the entry in every peer's config.
+- **A host whose advertised address differs from what nebula can see** (port forwarding, multiple internet paths) — set
+  [`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs) on that host. One config change,
+  propagates everywhere.
+- **Everything else** (laptops, NAT'd workstations, anything with a changing address) — dynamic discovery handles it
+  with no configuration at all.
+
+| Mechanism                                                                          | Configured where               | Propagates                             | Best for                                                        |
+| ---------------------------------------------------------------------------------- | ------------------------------ | -------------------------------------- | --------------------------------------------------------------- |
+| [`static_host_map`](/docs/config/static-host-map/)                                 | Every peer that dials the host | Manually, with each peer's config edit | Lighthouses (required); stable servers (optional)               |
+| [`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs) | The host being reached         | Automatically, via lighthouse reports  | Port forwarding, multiple paths, addresses nebula can't observe |
+| Automatic discovery                                                                | Nothing to configure           | Automatically, observed by lighthouses | Everything else                                                 |
+
+## Managed Nebula
+
+:::note
+
+In [Managed Nebula](https://admin.defined.net), each host's **static addresses** setting is inserted into every peer's
+generated config as its [`static_host_map`](/docs/config/static-host-map/) entry automatically — you never edit the map
+by hand, and lighthouses are required to have a static address for the reasons above.
+[`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs) is available through a host's
+advanced config overrides.
+
+:::
+
+## See also
+
+- [`static_host_map` reference](/docs/config/static-host-map/)
+- [`static_map` reference](/docs/config/static-map/)
+- [`lighthouse` reference](/docs/config/lighthouse/)
+- [`listen` reference](/docs/config/listen/)

--- a/docs/guides/quick-start/index.mdx
+++ b/docs/guides/quick-start/index.mdx
@@ -168,9 +168,12 @@ cp config.yml config.yaml
 
 #### Lighthouse configuration (`config-lighthouse.yaml`)
 
-On the lighthouse host, you'll need to ensure `am_lighthouse: true` is set. Generally, a lighthouse will not have any
-entries in its `static_host_map`, because all hosts will report themselves to a lighthouse. If you use multiple
-lighthouses, they do not generally need to know about each other.
+On the lighthouse host, you'll need to ensure [`am_lighthouse: true`](/docs/config/lighthouse/#lighthouseam_lighthouse)
+is set. Generally, a lighthouse will not have any entries in its [`static_host_map`](/docs/config/static-host-map/),
+because all hosts will report themselves to a lighthouse. If you use multiple lighthouses, they do not generally need to
+know about each other. (For why lighthouses appear in every other host's
+[`static_host_map`](/docs/config/static-host-map/) but not their own, see
+[How hosts find each other](/docs/guides/host-discovery/).)
 
 ```yaml
 static_host_map:
@@ -181,8 +184,9 @@ lighthouse:
 
 #### Host configuration (`config.yaml`)
 
-On the individual hosts, ensure the lighthouse is defined properly in the `static_host_map` section, and is added to the
-lighthouse `hosts` section.
+On the individual hosts, ensure the lighthouse is defined properly in the
+[`static_host_map`](/docs/config/static-host-map/) section, and is added to the
+[`lighthouse.hosts`](/docs/config/lighthouse/#lighthousehosts) section.
 
 ```yaml
 static_host_map:

--- a/docs/guides/rotating-certificate-authority/index.mdx
+++ b/docs/guides/rotating-certificate-authority/index.mdx
@@ -5,7 +5,7 @@ summary:
   This guide will teach you how to migrate from an expiring certificate authority by creating a new certificate
   authority, updating your device's Nebula config to trust the new authority, signing new host certificates, and
   removing the old certificate authority from the trust bundle.
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # How to rotate to a new certificate authority

--- a/docs/guides/running-nebula-as-non-root/index.mdx
+++ b/docs/guides/running-nebula-as-non-root/index.mdx
@@ -5,7 +5,7 @@ description:
 summary:
   On Linux, Nebula does not need to run as root. This guide shows how to run it as a dedicated unprivileged user by
   granting the CAP_NET_ADMIN capability, either through systemd or with file capabilities on the binary.
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Running Nebula as a non-root user

--- a/docs/guides/sign-certificates-with-public-keys/index.mdx
+++ b/docs/guides/sign-certificates-with-public-keys/index.mdx
@@ -4,7 +4,7 @@ description: How to sign Nebula certificates without copying private keys across
 summary:
   After reading this guide you will be able to create public/private keypairs on devices you wish to add to the Nebula
   network and generate certificates for them using only the public key.
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # How to use public keys to create signed certificates

--- a/docs/guides/unsafe_routes/index.mdx
+++ b/docs/guides/unsafe_routes/index.mdx
@@ -6,7 +6,7 @@ description:
 summary:
   This guide explains how to configure Nebula to route traffic destined for a specific subnet through a specific overlay
   network host, which is useful for accessing hosts that cannot be modified to run Nebula.
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Extending network access beyond overlay hosts

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -5,7 +5,7 @@ description:
   addresses.
 summary:
   This guide describes how to upgrade an existing nebula network to the v2 certificate format and enable IPv6 addresses.
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Upgrading a Nebula network to IPv6 overlay addresses

--- a/docs/guides/using-lighthouse-dns/index.mdx
+++ b/docs/guides/using-lighthouse-dns/index.mdx
@@ -2,7 +2,7 @@
 title: Using Lighthouse DNS with Nebula
 description:
   Configure Nebula's experimental built-in DNS server on Lighthouse hosts to resolve overlay network hostnames.
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Using Lighthouse DNS with Nebula

--- a/docs/guides/viewing-nebula-logs/index.mdx
+++ b/docs/guides/viewing-nebula-logs/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Viewing Nebula logs
 description: How to view Nebula logs on Linux, macOS, Windows, iOS, and Android for troubleshooting and monitoring.
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 import ThemedImage from '@theme/ThemedImage';


### PR DESCRIPTION
**Deploy preview:** https://push-mpkswpmozxnl.docs-nebula.pages.dev/ — new guide at [/docs/guides/host-discovery/](https://push-mpkswpmozxnl.docs-nebula.pages.dev/docs/guides/host-discovery/)

Adds a concept guide, How Hosts Find Each Other, explaining how a host learns a peer's routable underlay address: the static bootstrap path (`static_host_map`, dialed directly, works without lighthouses) versus lighthouse-mediated dynamic discovery (self-reported addresses, source-address learning for NAT'd hosts, `advertise_addrs`) — and when to use each, including why lighthouses must appear in every host's static host map while their own stays empty.

Supporting edits:

- `docs/config/static-host-map.mdx` — bootstrap framing, mixed IP/DNS name/IPv6 example, `static_map` cross-link, link to the guide
- `docs/config/lighthouse.mdx` — contrast paragraph in the `advertise_addrs` section (set once on the host vs edit every peer's config)
- `docs/guides/quick-start/index.mdx` — links the empty-lighthouse `static_host_map` example to the guide's explanation

Includes a Managed Nebula callout following the precedent in `intro.md` and the rotating-CA guide. `pnpm build` passes, so all new cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AU3rHtCYz5p8iNy5krguXn