### PR TITLE
Move onBrokenMarkdownLinks to markdown.hooks

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -28,8 +28,12 @@ const config: Config = {
   baseUrl: '/',
   trailingSlash: true,
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
   onBrokenAnchors: 'throw',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
+  },
   favicon: 'img/favicon.ico',
 
   plugins: [


### PR DESCRIPTION
Fixes the deprecation warning emitted on every build:

> [WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4. Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.

Same `'throw'` value, new location. `pnpm typecheck` and `pnpm build` pass with the warning gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AU3rHtCYz5p8iNy5krguXn