### PR TITLE
Add NAT traversal and firewalls guide

### DIFF
--- a/docs/config/punchy.mdx
+++ b/docs/config/punchy.mdx
@@ -8,8 +8,8 @@ import { Pill } from '@components/Pill/Pill';
 # punchy
 
 `punchy` configures the sending of inbound/outbound packets at a regular interval to avoid expiration of firewall NAT
-mappings. For when to reach for these settings — and the NAT behaviors that make them necessary — see
-[NAT Traversal and Firewalls](/docs/guides/nat-traversal/).
+mappings. See [NAT Traversal and Firewalls](/docs/guides/nat-traversal/) for when to reach for these settings and the
+NAT behaviors that make them necessary.
 
 Regardless of how `punchy` is configured, the Lighthouse will notify hosts when a peer is attempting to handshake with
 it and Nebula will issue an "empty" packet to the initiating peer's IP addresses in an attempt to punch a hole through

--- a/docs/config/punchy.mdx
+++ b/docs/config/punchy.mdx
@@ -8,7 +8,8 @@ import { Pill } from '@components/Pill/Pill';
 # punchy
 
 `punchy` configures the sending of inbound/outbound packets at a regular interval to avoid expiration of firewall NAT
-mappings.
+mappings. For when to reach for these settings — and the NAT behaviors that make them necessary — see
+[NAT Traversal and Firewalls](/docs/guides/nat-traversal/).
 
 Regardless of how `punchy` is configured, the Lighthouse will notify hosts when a peer is attempting to handshake with
 it and Nebula will issue an "empty" packet to the initiating peer's IP addresses in an attempt to punch a hole through

--- a/docs/config/relay.mdx
+++ b/docs/config/relay.mdx
@@ -15,6 +15,8 @@ Relay support was introduced in Nebula v1.6.0.
 
 Relay hosts forward traffic between two peers. This can be useful if two nodes struggle to communicate directly with
 each other (e.g. some NATs can make it difficult to establish direct connections between two nodes.)
+[NAT Traversal and Firewalls](/docs/guides/nat-traversal/) explains which NAT behaviors cause this and when relays are
+the right fix.
 
 ```yml
 relay:

--- a/docs/guides/debug-ssh-commands/index.mdx
+++ b/docs/guides/debug-ssh-commands/index.mdx
@@ -5,7 +5,7 @@ description:
 summary:
   This guide describes useful commands built into the SSH server accessible over nebula, which can allow debugging
   network connectivity for the nebula host.
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Debugging with Nebula SSH commands

--- a/docs/guides/host-discovery/index.mdx
+++ b/docs/guides/host-discovery/index.mdx
@@ -14,9 +14,8 @@ summary:
 
 Every host in your network has a Nebula IP, but that address only exists inside the overlay. To establish a tunnel with
 a peer, a host needs the peer's _underlay_ address — a routable IP and port like `203.0.113.42:4242` — to send packets
-to. Host discovery is how a host learns that address. Whether packets can actually flow once the address is known —
-through the NATs and firewalls in between — is the subject of
-[NAT Traversal and Firewalls](/docs/guides/nat-traversal/).
+to. Host discovery is how a host learns that address. Whether packets can actually get through the NATs and firewalls in
+between is covered in [NAT Traversal and Firewalls](/docs/guides/nat-traversal/).
 
 There are two ways a host can learn where to reach a peer:
 

--- a/docs/guides/host-discovery/index.mdx
+++ b/docs/guides/host-discovery/index.mdx
@@ -14,7 +14,9 @@ summary:
 
 Every host in your network has a Nebula IP, but that address only exists inside the overlay. To establish a tunnel with
 a peer, a host needs the peer's _underlay_ address — a routable IP and port like `203.0.113.42:4242` — to send packets
-to. Host discovery is how a host learns that address.
+to. Host discovery is how a host learns that address. Whether packets can actually flow once the address is known —
+through the NATs and firewalls in between — is the subject of
+[NAT Traversal and Firewalls](/docs/guides/nat-traversal/).
 
 There are two ways a host can learn where to reach a peer:
 
@@ -150,3 +152,4 @@ advanced config overrides.
 - [`static_map` reference](/docs/config/static-map/)
 - [`lighthouse` reference](/docs/config/lighthouse/)
 - [`listen` reference](/docs/config/listen/)
+- [NAT Traversal and Firewalls](/docs/guides/nat-traversal/)

--- a/docs/guides/nat-traversal/index.mdx
+++ b/docs/guides/nat-traversal/index.mdx
@@ -103,7 +103,10 @@ rely on relays when punching fails.
 **Short UDP timeouts.** A mapping that expires between packets looks like a tunnel that "randomly" stops passing traffic
 until the next handshake. This can happen on any NAT type. Enable [`punchy.punch`](/docs/config/punchy/#punchypunch)
 (and consider [`punchy.respond`](/docs/config/punchy/#punchyrespond)) on affected hosts before touching firewall
-timeouts.
+timeouts. Short timeouts also age the address a lighthouse has on file: when a mapping expires and the next outbound
+packet creates a new one, peers keep dialing the old address until the host's next report. Lowering
+[`lighthouse.interval`](/docs/config/lighthouse/#lighthouseinterval) below the network's UDP timeout shrinks that stale
+window and keeps the mapping toward the lighthouse alive in the first place.
 
 **Different paths, different rules.** Two paths out of the same network can behave differently, because wired and
 wireless VLANs often pass through different firewall zones or NAT rules. A tunnel that comes up on one VLAN and fails on

--- a/docs/guides/nat-traversal/index.mdx
+++ b/docs/guides/nat-traversal/index.mdx
@@ -12,8 +12,8 @@ summary:
 
 # NAT Traversal and Firewalls
 
-Nebula sends everything over a single UDP socket: handshakes, tunneled traffic, and reports to
-[lighthouses](/docs/config/lighthouse/). Connections always start from the inside out. Because of this, most hosts
+Nebula sends handshakes, tunneled traffic, and reports to [lighthouses](/docs/config/lighthouse/) over a single UDP
+socket. Connections always start from the inside out. Because of this, most hosts
 behind home routers and office firewalls can build direct tunnels with no changes to those devices at all. This guide is
 for the cases where that doesn't happen. It explains what Nebula needs from the network path, which firewall and NAT
 (network address translation) behaviors break hole punching, and what to reach for when a direct tunnel isn't possible.
@@ -21,7 +21,7 @@ for the cases where that doesn't happen. It explains what Nebula needs from the 
 ## How hole punching works
 
 [Host discovery](/docs/guides/host-discovery/) gives each host a list of addresses where a peer might be reachable. The
-list includes the source address a lighthouse saw on the peer's report packets — what that peer looks like from the
+list includes the source address a lighthouse saw on the peer's report packets. That's what the peer looks like from the
 public side of its NAT.
 
 When host A wants to tunnel to host B:
@@ -34,12 +34,12 @@ When host A wants to tunnel to host B:
    two hosts.
 
 Neither side needs an inbound firewall rule, because each NAT saw outbound traffic first. But step 2 only works if other
-peers can actually use the address the lighthouse saw. That depends on how the NAT hands out mappings, which is what the
-[NAT types](#nat-types) below are about.
+peers can actually use the address the lighthouse saw, and that depends on how the NAT hands out mappings. The
+[NAT types](#nat-types) below cover that.
 
 ## What Nebula needs from the network
 
-If Nebula hosts sit behind a firewall you manage, this is the checklist:
+If Nebula hosts sit behind a firewall you manage, make sure it allows the following:
 
 - **Outbound UDP, with return traffic.** Hosts must be able to send UDP to lighthouse and [relay](/docs/config/relay/)
   ports, and to the (usually random) ports of other peers. Nebula has no TCP fallback. Most deep-inspection firewalls
@@ -57,15 +57,15 @@ If Nebula hosts sit behind a firewall you manage, this is the checklist:
 ## NAT types
 
 Whether hole punching succeeds depends on how each side's NAT hands out external mappings. From Nebula's point of view,
-every host falls into one of three types. A tunnel's fate is a property of the _pair_ of types
-([see the table below](#what-to-expect-pair-by-pair)), not of either host alone.
+every host falls into one of three types. What happens to a tunnel depends on the _pair_ of types
+([see the table below](#what-to-expect-pair-by-pair)), not on either host alone.
 
 ### Public address
 
 The host can be reached at a fixed, known address, so no punching is involved. Either the host has its own public IP, or
 a port forward points at it and the forwarded address is advertised with
 [`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs). A port forward needs a fixed
-[`listen.port`](/docs/config/listen/) behind it — the default is a random port that changes on restart, which silently
+[`listen.port`](/docs/config/listen/) behind it. The default is a random port that changes on restart, which silently
 breaks the forward. Lighthouses and relays must have a public address. For any other host it's optional, but it skips
 NAT traversal entirely.
 
@@ -83,18 +83,18 @@ pairing in the table below says "usually," not "always."
 ### Hard NAT (symmetric NAT, CGNAT)
 
 The NAT creates a fresh external port for each new destination. The address a lighthouse sees is then only valid for
-traffic to that lighthouse — peers that dial it hit a dead mapping. Two hosts behind hard NAT cannot punch a tunnel at
+traffic to that lighthouse. Peers that dial it hit a dead mapping. Two hosts behind hard NAT cannot punch a tunnel at
 all. When only one side is affected, enabling [`punchy.respond`](/docs/config/punchy/#punchyrespond) sometimes rescues
 the handshake by having the difficult side start it in reverse.
 
 Enterprise firewalls often default to this behavior. On Palo Alto firewalls, for example, the standard Dynamic IP and
 Port (DIPP) source NAT creates a new translation per session. PAN-OS offers
 [Persistent NAT for DIPP](https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-new-features/networking-features/persistent-nat-for-dipp)
-precisely to restore easy-NAT behavior for protocols like STUN — and Nebula benefits the same way.
+to restore easy-NAT behavior for protocols like STUN, and Nebula benefits the same way.
 
 Carrier-grade NAT (CGNAT) usually lands here too. Cell networks and some ISPs put customers behind CGNAT, which often
-combines per-destination ports with short timeouts and shared public addresses. Hosts behind CGNAT still work — through
-relays when punching fails.
+combines per-destination ports with short timeouts and shared public addresses. Hosts behind CGNAT still work. They just
+rely on relays when punching fails.
 
 ### Look-alikes that aren't a NAT type
 
@@ -119,9 +119,9 @@ Lighthouses and relays are [required to have a public address](#public-address).
 still has a working fallback.
 
 \* The mixed pairing is direct but direction-sensitive. The host behind the hard NAT can still dial _out_ to its peer's
-valid observed address, so the handshake succeeds only when it starts from that side — and only if the easy side's
+valid observed address, so the handshake succeeds only when it starts from that side, and only if the easy side's
 [inbound filtering](#easy-nat-endpoint-independent) accepts it. [`punchy.respond`](/docs/config/punchy/#punchyrespond)
-exists for exactly this: it has the difficult side retry the handshake in the reverse direction, no matter which host
+exists for this: it has the difficult side retry the handshake in the reverse direction, no matter which host
 wanted the tunnel.
 
 ## When punching fails anyway
@@ -137,9 +137,9 @@ In rough order of preference:
    stable target, and see [How Hosts Find Each Other](/docs/guides/host-discovery/) for how the advertised address
    spreads.
 3. **Use relays.** [Relays](/docs/config/relay/) are the designed fallback when no direct path exists. A host that both
-   peers can reach forwards traffic between them. The tunnel stays end-to-end encrypted — the relay can see routing
-   metadata, but not contents. The cost is performance, not security: traffic takes an extra hop, so expect added
-   latency, and throughput is limited by the relay's own connection.
+   peers can reach forwards traffic between them. The tunnel stays end-to-end encrypted. The relay can see routing
+   metadata, but not contents. Traffic takes an extra hop, so expect added latency, and throughput is limited by the
+   relay's own connection.
 
 ## Telling direct from relayed
 
@@ -153,7 +153,7 @@ msg="Handshake message received" from="203.0.113.9:4242 (relayed)" ...
 msg="Send handshake via relay" relay=192.168.100.1 ...
 ```
 
-A host that always handshakes `(relayed)` with peers it should reach directly is the signature of one of the
+A host that always handshakes `(relayed)` with peers it should reach directly usually points at one of the
 [hard NAT behaviors](#hard-nat-symmetric-nat-cgnat) above. The [debug SSH commands](/docs/guides/debug-ssh-commands/)
 can also print the current remotes and relays for each tunnel.
 
@@ -163,8 +163,8 @@ can also print the current remotes and relays for each tunnel.
 
 In [Managed Nebula](https://admin.defined.net), generated configs enable
 [`punchy.punch`](/docs/config/punchy/#punchypunch) and [`punchy.respond`](/docs/config/punchy/#punchyrespond) on every
-host. (Lighthouses are the exception — they shouldn't be behind a NAT.) Lighthouses require a static address, and any
-host can be made a relay from the admin panel — see
+host except lighthouses, which shouldn't be behind a NAT. Lighthouses require a static address, and any host can be made
+a relay from the admin panel. See
 [Using dedicated relays](https://docs.defined.net/guides/using-dedicated-relays/).
 
 :::

--- a/docs/guides/nat-traversal/index.mdx
+++ b/docs/guides/nat-traversal/index.mdx
@@ -1,0 +1,146 @@
+---
+sidebar_position: 3
+title: NAT Traversal and Firewalls
+description:
+  What Nebula needs from the firewalls and NATs between hosts — how UDP hole punching works, which NAT behaviors break
+  it, and the fallbacks available when a direct tunnel cannot be established.
+summary:
+  Nebula establishes direct peer-to-peer tunnels through most NATs and firewalls without any configuration on those
+  devices. This guide explains how hole punching works, what a firewall must (and must not) do for it to succeed, and
+  what to reach for when the network gets in the way.
+---
+
+# NAT Traversal and Firewalls
+
+Nebula carries everything — handshakes, tunneled traffic, lighthouse reports — over a single UDP socket, and always
+initiates from the inside out. Most hosts behind home routers and office firewalls establish direct tunnels with no
+changes to those devices at all. This guide is for the cases where that doesn't happen: what Nebula needs from the
+network path, which firewall and NAT behaviors break hole punching, and the tools available when a direct tunnel isn't
+possible.
+
+## How hole punching works
+
+[Host discovery](/docs/guides/host-discovery/) gives each host a set of addresses where a peer might be reachable —
+including the source address a lighthouse observed on the peer's report packets, which is what that peer looks like from
+the public side of its NAT.
+
+When host A wants to tunnel to host B:
+
+1. A asks its lighthouses for B's addresses and starts sending handshake packets to them. On the way out, A's own NAT
+   creates a mapping that allows return traffic in.
+2. The lighthouse notifies B that A is trying to reach it, and B sends an "empty" packet toward A's addresses. This
+   punches a hole in B's NAT from the inside, so A's handshake packets are treated as return traffic and let through.
+3. As soon as a handshake succeeds in either direction, both NATs hold live mappings and traffic flows directly between
+   the two hosts.
+
+Neither side needs an inbound firewall rule, because each NAT saw outbound traffic first. But step 2 only helps if the
+address the lighthouse observed is actually usable by _other_ peers — and that depends entirely on how the NAT allocates
+mappings, which is where the trouble starts.
+
+## What Nebula needs from the network
+
+If you administer a firewall that Nebula hosts sit behind, this is the checklist:
+
+- **Outbound UDP, with return traffic.** Hosts must be able to send UDP to lighthouse and relay ports, and to the
+  (usually ephemeral) ports of other peers. Nebula has no TCP fallback. Deep-inspection firewalls that classify traffic
+  won't recognize the protocol — expect it to show up as unknown UDP and allow it.
+- **Consistent NAT mappings.** When a host sends from the same internal address and port to several destinations, the
+  NAT should reuse one external mapping for all of them — behavior known as _endpoint-independent mapping_ (RFC 4787),
+  and marketed variously as "persistent NAT" or "full-cone NAT". This is the property that makes the lighthouse-observed
+  address valid for everyone else. Its opposite — a fresh external port per destination, often called _symmetric NAT_ —
+  is the single most common reason hole punching fails.
+- **UDP timeouts that outlive idle periods, or keepalives.** NAT mappings expire when idle. Enabling
+  [`punchy.punch`](/docs/config/punchy/#punchypunch) makes hosts send periodic empty packets to keep established
+  mappings alive, which is much easier than tuning timeouts on every middlebox in the path.
+- **Inbound reachability for lighthouses and relays only.** These are the two roles that must be dialable at a stable
+  address and UDP port (conventionally `4242`) — via a public IP or a port forward. Ordinary hosts need nothing inbound.
+
+## NAT behaviors that break hole punching
+
+**Symmetric NAT / per-session port allocation.** If the NAT allocates a new external port for each new destination, the
+address a lighthouse observes is only valid for traffic to that lighthouse — peers dialing it hit a dead mapping.
+Tunnels between two such hosts cannot be punched at all; when only one side is affected, enabling
+[`punchy.respond`](/docs/config/punchy/#punchyrespond) sometimes rescues the handshake by having the difficult side
+initiate in reverse. Enterprise firewalls commonly default to this behavior. On Palo Alto firewalls, for example, the
+standard Dynamic IP and Port (DIPP) source NAT allocates translations per session; PAN-OS offers
+[Persistent NAT for DIPP](https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-new-features/networking-features/persistent-nat-for-dipp)
+precisely to restore endpoint-independent mapping for protocols like STUN — and Nebula benefits the same way.
+
+**Carrier-grade NAT.** Cellular networks and some ISPs put customers behind CGNAT, which frequently combines
+symmetric-style allocation with aggressive timeouts and shared public addresses. Hosts behind CGNAT usually still work —
+via relays when punching fails.
+
+**Short UDP timeouts.** A mapping that expires between packets looks like a tunnel that "randomly" stops passing traffic
+until the next handshake. Enable [`punchy.punch`](/docs/config/punchy/#punchypunch) (and consider
+[`punchy.respond`](/docs/config/punchy/#punchyrespond)) on affected hosts before reaching for firewall timeout changes.
+
+Note that two paths from the same office can behave differently: wired and wireless VLANs often traverse different
+firewall zones or NAT rules, so "works on Wi-Fi, fails on ethernet" (or the reverse) usually points at policy on the
+network, not at the hosts.
+
+### What to expect, pair by pair
+
+Whether a direct tunnel is possible is a property of the _pair_ of NAT behaviors, not of either host alone:
+
+| One host ↓ · the other → | Dialable address | Endpoint-independent NAT | Symmetric NAT or CGNAT      |
+| ------------------------ | ---------------- | ------------------------ | --------------------------- |
+| **Dialable address**     | Direct           | Direct                   | Direct                      |
+| **Endpoint-independent** | Direct           | Direct — hole punching   | Direct, one-way — see below |
+| **Symmetric or CGNAT**   | Direct           | Direct, one-way          | Relayed — no punchable path |
+
+A _dialable address_ means a public IP or a port forward advertised via
+[`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs) — lighthouses and relays are required
+to live in this row, which is why every other pairing still has a working fallback.
+
+The mixed case is direct but direction-sensitive: the host behind the symmetric NAT can still dial _out_ to its peer's
+valid observed address, so the handshake succeeds only when it originates from that side.
+[`punchy.respond`](/docs/config/punchy/#punchyrespond) exists for exactly this — it has the difficult side retry the
+handshake in the reverse direction, whichever host wanted the tunnel.
+
+## When punching fails anyway
+
+In rough order of preference:
+
+1. **Enable punchy.** [`punchy.punch`](/docs/config/punchy/#punchypunch) keeps mappings alive;
+   [`punchy.respond`](/docs/config/punchy/#punchyrespond) retries the handshake in the reverse direction, which rescues
+   some one-sided NAT situations.
+2. **Give the host a dialable address.** A port forward plus
+   [`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs) sidesteps observation entirely —
+   peers dial a known-good address, no punching required. See [How Hosts Find Each Other](/docs/guides/host-discovery/).
+3. **Use relays.** [Relays](/docs/config/relay/) are the designed fallback when no direct path exists: a mutually
+   reachable host forwards traffic between the two peers, and the tunnel stays end-to-end encrypted — the relay can see
+   routing metadata but not contents.
+
+## Telling direct from relayed
+
+A relayed tunnel works, so it's easy to not notice one. In the logs (see
+[Viewing Nebula logs](/docs/guides/viewing-nebula-logs/)), the `from` field on `Handshake message received` lines shows
+a plain address for a direct tunnel and is suffixed for a relayed one:
+
+```
+msg="Handshake message received" from="203.0.113.9:4242 (relayed)" ...
+msg="Send handshake via relay" relay=192.168.100.1 ...
+```
+
+A host that consistently handshakes `(relayed)` with peers it should reach directly is the signature of one of the NAT
+behaviors above. The [debug SSH commands](/docs/guides/debug-ssh-commands/) can also print the current remotes and
+relays for each tunnel.
+
+## Managed Nebula
+
+:::note
+
+In [Managed Nebula](https://admin.defined.net), generated configs enable
+[`punchy.punch`](/docs/config/punchy/#punchypunch) and [`punchy.respond`](/docs/config/punchy/#punchyrespond) on every
+host (lighthouses excepted — they shouldn't be behind a NAT), lighthouses require a static address, and any host can be
+made a relay from the admin panel — see
+[Using dedicated relays](https://docs.defined.net/guides/using-dedicated-relays/).
+
+:::
+
+## See also
+
+- [`punchy` reference](/docs/config/punchy/)
+- [`relay` reference](/docs/config/relay/)
+- [`listen` reference](/docs/config/listen/)
+- [How Hosts Find Each Other](/docs/guides/host-discovery/)

--- a/docs/guides/nat-traversal/index.mdx
+++ b/docs/guides/nat-traversal/index.mdx
@@ -13,18 +13,18 @@ summary:
 # NAT Traversal and Firewalls
 
 Nebula sends handshakes, tunneled traffic, and reports to [lighthouses](/docs/config/lighthouse/) over a single UDP
-socket. Connections always start from the inside out. Because of this, most hosts
-behind home routers and office firewalls can build direct tunnels with no changes to those devices at all. This guide is
-for the cases where that doesn't happen. It explains what Nebula needs from the network path, which firewall and NAT
-(network address translation) behaviors break hole punching, and what to reach for when a direct tunnel isn't possible.
+socket, and connections always start from the inside out. That's why most hosts behind home routers and office firewalls
+can build direct tunnels with no changes to those devices at all. This guide is for the cases where that doesn't happen:
+it explains what Nebula needs from the network path, which firewall and NAT (network address translation) behaviors
+break hole punching, and what to reach for when a direct tunnel isn't possible.
 
 ## How hole punching works
 
-[Host discovery](/docs/guides/host-discovery/) gives each host a list of addresses where a peer might be reachable. The
-list includes the source address a lighthouse saw on the peer's report packets. That's what the peer looks like from the
-public side of its NAT.
+[Host discovery](/docs/guides/host-discovery/) gives each host a list of addresses where a peer might be reachable,
+including the source address a lighthouse saw on the peer's report packets. That address is what the peer looks like
+from the public side of its NAT.
 
-When host A wants to tunnel to host B:
+Say host A sits on a home network, host B is at an office, and A wants to tunnel to B:
 
 1. A asks its lighthouses for B's addresses and starts sending handshake packets to them. As those packets leave, A's
    own NAT creates a mapping that lets return traffic back in.
@@ -43,7 +43,8 @@ If Nebula hosts sit behind a firewall you manage, make sure it allows the follow
 
 - **Outbound UDP, with return traffic.** Hosts must be able to send UDP to lighthouse and [relay](/docs/config/relay/)
   ports, and to the (usually random) ports of other peers. Nebula has no TCP fallback. Most deep-inspection firewalls
-  won't recognize the protocol. Expect it to show up as unknown UDP, and allow it.
+  won't recognize the protocol, so expect it to show up as unknown UDP and allow it. Networks that block unrecognized
+  UDP break Nebula the same way they break QUIC.
 - **Consistent NAT mappings.** When a host sends from one internal address and port to several destinations, the NAT
   should reuse one external mapping for all of them. This is the [easy NAT](#easy-nat-endpoint-independent) behavior
   described below, and it's what makes the address the lighthouse saw valid for everyone else. Its absence is the most
@@ -72,28 +73,29 @@ NAT traversal entirely.
 ### Easy NAT (endpoint-independent)
 
 The NAT reuses one external mapping for everything a host sends from one internal address and port, no matter the
-destination. RFC 4787 calls this _endpoint-independent mapping_; vendors loosely market it as "persistent NAT" or
-"full-cone NAT". Every peer sees the same external address the lighthouse saw, so hole punching works. Home routers and
-most smaller office firewalls behave this way.
+destination. [RFC 4787](https://www.rfc-editor.org/rfc/rfc4787.html#section-4.1) calls this _endpoint-independent
+mapping_; vendors loosely market it as "persistent NAT" or "full-cone NAT". Every peer sees the same external address
+the lighthouse saw, so hole punching works. Home routers and most smaller office firewalls behave this way.
 
-One caveat: RFC 4787 grades a NAT's mapping and its inbound _filtering_ separately. A NAT can reuse one mapping but
-still drop inbound packets from addresses and ports its host hasn't sent to. That stricter filtering is why the mixed
-pairing in the table below says "usually," not "always."
+One caveat: RFC 4787 grades a NAT's mapping and its inbound
+[_filtering_](https://www.rfc-editor.org/rfc/rfc4787.html#section-5) separately. A NAT can reuse one mapping but still
+drop inbound packets from addresses and ports its host hasn't sent to. That stricter filtering is why the mixed pairing
+in the table below says "usually," not "always."
 
 ### Hard NAT (symmetric NAT, CGNAT)
 
-The NAT creates a fresh external port for each new destination. The address a lighthouse sees is then only valid for
+The NAT creates a fresh external port for each new destination, so the address a lighthouse sees is only valid for
 traffic to that lighthouse. Peers that dial it hit a dead mapping. Two hosts behind hard NAT cannot punch a tunnel at
 all. When only one side is affected, enabling [`punchy.respond`](/docs/config/punchy/#punchyrespond) sometimes rescues
 the handshake by having the difficult side start it in reverse.
 
-Enterprise firewalls often default to this behavior. On Palo Alto firewalls, for example, the standard Dynamic IP and
-Port (DIPP) source NAT creates a new translation per session. PAN-OS offers
-[Persistent NAT for DIPP](https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-new-features/networking-features/persistent-nat-for-dipp)
-to restore easy-NAT behavior for protocols like STUN, and Nebula benefits the same way.
+Enterprise firewalls often default to this behavior, creating a new source-NAT translation for every session. Many of
+them also offer a persistent or endpoint-independent mode, added for protocols like STUN, and Nebula benefits from it
+the same way. If hole punching fails behind a firewall you control, look for that setting before reaching for the
+fallbacks below.
 
 Carrier-grade NAT (CGNAT) usually lands here too. Cell networks and some ISPs put customers behind CGNAT, which often
-combines per-destination ports with short timeouts and shared public addresses. Hosts behind CGNAT still work. They just
+combines per-destination ports with short timeouts and shared public addresses. Hosts behind CGNAT still work; they just
 rely on relays when punching fails.
 
 ### Look-alikes that aren't a NAT type
@@ -103,9 +105,9 @@ until the next handshake. This can happen on any NAT type. Enable [`punchy.punch
 (and consider [`punchy.respond`](/docs/config/punchy/#punchyrespond)) on affected hosts before touching firewall
 timeouts.
 
-**Different paths, different rules.** Two paths out of the same office can behave differently. Wired and wireless VLANs
-often pass through different firewall zones or NAT rules. So "works on Wi-Fi, fails on ethernet" (or the reverse)
-usually points at policy on the network, not at the hosts.
+**Different paths, different rules.** Two paths out of the same network can behave differently, because wired and
+wireless VLANs often pass through different firewall zones or NAT rules. A tunnel that comes up on one VLAN and fails on
+another usually points at policy on the network, not at the hosts.
 
 ### What to expect, pair by pair
 
@@ -121,8 +123,8 @@ still has a working fallback.
 \* The mixed pairing is direct but direction-sensitive. The host behind the hard NAT can still dial _out_ to its peer's
 valid observed address, so the handshake succeeds only when it starts from that side, and only if the easy side's
 [inbound filtering](#easy-nat-endpoint-independent) accepts it. [`punchy.respond`](/docs/config/punchy/#punchyrespond)
-exists for this: it has the difficult side retry the handshake in the reverse direction, no matter which host
-wanted the tunnel.
+exists for this: it has the difficult side retry the handshake in the reverse direction, no matter which host wanted the
+tunnel.
 
 ## When punching fails anyway
 
@@ -137,7 +139,7 @@ In rough order of preference:
    stable target, and see [How Hosts Find Each Other](/docs/guides/host-discovery/) for how the advertised address
    spreads.
 3. **Use relays.** [Relays](/docs/config/relay/) are the designed fallback when no direct path exists. A host that both
-   peers can reach forwards traffic between them. The tunnel stays end-to-end encrypted. The relay can see routing
+   peers can reach forwards traffic between them. The tunnel stays end-to-end encrypted; the relay can see routing
    metadata, but not contents. Traffic takes an extra hop, so expect added latency, and throughput is limited by the
    relay's own connection.
 
@@ -164,8 +166,7 @@ can also print the current remotes and relays for each tunnel.
 In [Managed Nebula](https://admin.defined.net), generated configs enable
 [`punchy.punch`](/docs/config/punchy/#punchypunch) and [`punchy.respond`](/docs/config/punchy/#punchyrespond) on every
 host except lighthouses, which shouldn't be behind a NAT. Lighthouses require a static address, and any host can be made
-a relay from the admin panel. See
-[Using dedicated relays](https://docs.defined.net/guides/using-dedicated-relays/).
+a relay from the admin panel. See [Using dedicated relays](https://docs.defined.net/guides/using-dedicated-relays/).
 
 :::
 

--- a/docs/guides/nat-traversal/index.mdx
+++ b/docs/guides/nat-traversal/index.mdx
@@ -12,119 +12,150 @@ summary:
 
 # NAT Traversal and Firewalls
 
-Nebula carries everything — handshakes, tunneled traffic, lighthouse reports — over a single UDP socket, and always
-initiates from the inside out. Most hosts behind home routers and office firewalls establish direct tunnels with no
-changes to those devices at all. This guide is for the cases where that doesn't happen: what Nebula needs from the
-network path, which firewall and NAT behaviors break hole punching, and the tools available when a direct tunnel isn't
-possible.
+Nebula sends everything over a single UDP socket: handshakes, tunneled traffic, and reports to
+[lighthouses](/docs/config/lighthouse/). Connections always start from the inside out. Because of this, most hosts
+behind home routers and office firewalls can build direct tunnels with no changes to those devices at all. This guide is
+for the cases where that doesn't happen. It explains what Nebula needs from the network path, which firewall and NAT
+(network address translation) behaviors break hole punching, and what to reach for when a direct tunnel isn't possible.
 
 ## How hole punching works
 
-[Host discovery](/docs/guides/host-discovery/) gives each host a set of addresses where a peer might be reachable —
-including the source address a lighthouse observed on the peer's report packets, which is what that peer looks like from
-the public side of its NAT.
+[Host discovery](/docs/guides/host-discovery/) gives each host a list of addresses where a peer might be reachable. The
+list includes the source address a lighthouse saw on the peer's report packets — what that peer looks like from the
+public side of its NAT.
 
 When host A wants to tunnel to host B:
 
-1. A asks its lighthouses for B's addresses and starts sending handshake packets to them. On the way out, A's own NAT
-   creates a mapping that allows return traffic in.
-2. The lighthouse notifies B that A is trying to reach it, and B sends an "empty" packet toward A's addresses. This
-   punches a hole in B's NAT from the inside, so A's handshake packets are treated as return traffic and let through.
-3. As soon as a handshake succeeds in either direction, both NATs hold live mappings and traffic flows directly between
-   the two hosts.
+1. A asks its lighthouses for B's addresses and starts sending handshake packets to them. As those packets leave, A's
+   own NAT creates a mapping that lets return traffic back in.
+2. The lighthouse tells B that A is trying to reach it. B sends an "empty" packet toward A's addresses. This punches a
+   hole in B's NAT from the inside, so B's NAT treats A's handshake packets as return traffic and lets them through.
+3. Once a handshake succeeds in either direction, both NATs hold live mappings. Traffic now flows directly between the
+   two hosts.
 
-Neither side needs an inbound firewall rule, because each NAT saw outbound traffic first. But step 2 only helps if the
-address the lighthouse observed is actually usable by _other_ peers — and that depends entirely on how the NAT allocates
-mappings, which is where the trouble starts.
+Neither side needs an inbound firewall rule, because each NAT saw outbound traffic first. But step 2 only works if other
+peers can actually use the address the lighthouse saw. That depends on how the NAT hands out mappings, which is what the
+[NAT types](#nat-types) below are about.
 
 ## What Nebula needs from the network
 
-If you administer a firewall that Nebula hosts sit behind, this is the checklist:
+If Nebula hosts sit behind a firewall you manage, this is the checklist:
 
-- **Outbound UDP, with return traffic.** Hosts must be able to send UDP to lighthouse and relay ports, and to the
-  (usually ephemeral) ports of other peers. Nebula has no TCP fallback. Deep-inspection firewalls that classify traffic
-  won't recognize the protocol — expect it to show up as unknown UDP and allow it.
-- **Consistent NAT mappings.** When a host sends from the same internal address and port to several destinations, the
-  NAT should reuse one external mapping for all of them — behavior known as _endpoint-independent mapping_ (RFC 4787),
-  and marketed variously as "persistent NAT" or "full-cone NAT". This is the property that makes the lighthouse-observed
-  address valid for everyone else. Its opposite — a fresh external port per destination, often called _symmetric NAT_ —
-  is the single most common reason hole punching fails.
+- **Outbound UDP, with return traffic.** Hosts must be able to send UDP to lighthouse and [relay](/docs/config/relay/)
+  ports, and to the (usually random) ports of other peers. Nebula has no TCP fallback. Most deep-inspection firewalls
+  won't recognize the protocol. Expect it to show up as unknown UDP, and allow it.
+- **Consistent NAT mappings.** When a host sends from one internal address and port to several destinations, the NAT
+  should reuse one external mapping for all of them. This is the [easy NAT](#easy-nat-endpoint-independent) behavior
+  described below, and it's what makes the address the lighthouse saw valid for everyone else. Its absence is the most
+  common reason hole punching fails.
 - **UDP timeouts that outlive idle periods, or keepalives.** NAT mappings expire when idle. Enabling
-  [`punchy.punch`](/docs/config/punchy/#punchypunch) makes hosts send periodic empty packets to keep established
-  mappings alive, which is much easier than tuning timeouts on every middlebox in the path.
-- **Inbound reachability for lighthouses and relays only.** These are the two roles that must be dialable at a stable
-  address and UDP port (conventionally `4242`) — via a public IP or a port forward. Ordinary hosts need nothing inbound.
+  [`punchy.punch`](/docs/config/punchy/#punchypunch) makes hosts send small keepalive packets that hold live mappings
+  open. That's much easier than tuning timeouts on every device in the path.
+- **Inbound reachability for lighthouses and relays only.** These two roles must be reachable at a stable public address
+  and UDP port (usually `4242`), through a public IP or a port forward. Ordinary hosts need nothing inbound.
 
-## NAT behaviors that break hole punching
+## NAT types
 
-**Symmetric NAT / per-session port allocation.** If the NAT allocates a new external port for each new destination, the
-address a lighthouse observes is only valid for traffic to that lighthouse — peers dialing it hit a dead mapping.
-Tunnels between two such hosts cannot be punched at all; when only one side is affected, enabling
-[`punchy.respond`](/docs/config/punchy/#punchyrespond) sometimes rescues the handshake by having the difficult side
-initiate in reverse. Enterprise firewalls commonly default to this behavior. On Palo Alto firewalls, for example, the
-standard Dynamic IP and Port (DIPP) source NAT allocates translations per session; PAN-OS offers
+Whether hole punching succeeds depends on how each side's NAT hands out external mappings. From Nebula's point of view,
+every host falls into one of three types. A tunnel's fate is a property of the _pair_ of types
+([see the table below](#what-to-expect-pair-by-pair)), not of either host alone.
+
+### Public address
+
+The host can be reached at a fixed, known address, so no punching is involved. Either the host has its own public IP, or
+a port forward points at it and the forwarded address is advertised with
+[`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs). A port forward needs a fixed
+[`listen.port`](/docs/config/listen/) behind it — the default is a random port that changes on restart, which silently
+breaks the forward. Lighthouses and relays must have a public address. For any other host it's optional, but it skips
+NAT traversal entirely.
+
+### Easy NAT (endpoint-independent)
+
+The NAT reuses one external mapping for everything a host sends from one internal address and port, no matter the
+destination. RFC 4787 calls this _endpoint-independent mapping_; vendors loosely market it as "persistent NAT" or
+"full-cone NAT". Every peer sees the same external address the lighthouse saw, so hole punching works. Home routers and
+most smaller office firewalls behave this way.
+
+One caveat: RFC 4787 grades a NAT's mapping and its inbound _filtering_ separately. A NAT can reuse one mapping but
+still drop inbound packets from addresses and ports its host hasn't sent to. That stricter filtering is why the mixed
+pairing in the table below says "usually," not "always."
+
+### Hard NAT (symmetric NAT, CGNAT)
+
+The NAT creates a fresh external port for each new destination. The address a lighthouse sees is then only valid for
+traffic to that lighthouse — peers that dial it hit a dead mapping. Two hosts behind hard NAT cannot punch a tunnel at
+all. When only one side is affected, enabling [`punchy.respond`](/docs/config/punchy/#punchyrespond) sometimes rescues
+the handshake by having the difficult side start it in reverse.
+
+Enterprise firewalls often default to this behavior. On Palo Alto firewalls, for example, the standard Dynamic IP and
+Port (DIPP) source NAT creates a new translation per session. PAN-OS offers
 [Persistent NAT for DIPP](https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-new-features/networking-features/persistent-nat-for-dipp)
-precisely to restore endpoint-independent mapping for protocols like STUN — and Nebula benefits the same way.
+precisely to restore easy-NAT behavior for protocols like STUN — and Nebula benefits the same way.
 
-**Carrier-grade NAT.** Cellular networks and some ISPs put customers behind CGNAT, which frequently combines
-symmetric-style allocation with aggressive timeouts and shared public addresses. Hosts behind CGNAT usually still work —
-via relays when punching fails.
+Carrier-grade NAT (CGNAT) usually lands here too. Cell networks and some ISPs put customers behind CGNAT, which often
+combines per-destination ports with short timeouts and shared public addresses. Hosts behind CGNAT still work — through
+relays when punching fails.
+
+### Look-alikes that aren't a NAT type
 
 **Short UDP timeouts.** A mapping that expires between packets looks like a tunnel that "randomly" stops passing traffic
-until the next handshake. Enable [`punchy.punch`](/docs/config/punchy/#punchypunch) (and consider
-[`punchy.respond`](/docs/config/punchy/#punchyrespond)) on affected hosts before reaching for firewall timeout changes.
+until the next handshake. This can happen on any NAT type. Enable [`punchy.punch`](/docs/config/punchy/#punchypunch)
+(and consider [`punchy.respond`](/docs/config/punchy/#punchyrespond)) on affected hosts before touching firewall
+timeouts.
 
-Note that two paths from the same office can behave differently: wired and wireless VLANs often traverse different
-firewall zones or NAT rules, so "works on Wi-Fi, fails on ethernet" (or the reverse) usually points at policy on the
-network, not at the hosts.
+**Different paths, different rules.** Two paths out of the same office can behave differently. Wired and wireless VLANs
+often pass through different firewall zones or NAT rules. So "works on Wi-Fi, fails on ethernet" (or the reverse)
+usually points at policy on the network, not at the hosts.
 
 ### What to expect, pair by pair
 
-Whether a direct tunnel is possible is a property of the _pair_ of NAT behaviors, not of either host alone:
+| One host ↓ · the other → | Public address | Easy NAT                  | Hard NAT                    |
+| ------------------------ | -------------- | ------------------------- | --------------------------- |
+| **Public address**       | Direct         | Direct                    | Direct                      |
+| **Easy NAT**             | Direct         | Direct — hole punching    | Usually direct, one-way\*   |
+| **Hard NAT**             | Direct         | Usually direct, one-way\* | Relayed — no punchable path |
 
-| One host ↓ · the other → | Dialable address | Endpoint-independent NAT | Symmetric NAT or CGNAT      |
-| ------------------------ | ---------------- | ------------------------ | --------------------------- |
-| **Dialable address**     | Direct           | Direct                   | Direct                      |
-| **Endpoint-independent** | Direct           | Direct — hole punching   | Direct, one-way — see below |
-| **Symmetric or CGNAT**   | Direct           | Direct, one-way          | Relayed — no punchable path |
+Lighthouses and relays are [required to have a public address](#public-address). That's why every pairing in the table
+still has a working fallback.
 
-A _dialable address_ means a public IP or a port forward advertised via
-[`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs) — lighthouses and relays are required
-to live in this row, which is why every other pairing still has a working fallback.
-
-The mixed case is direct but direction-sensitive: the host behind the symmetric NAT can still dial _out_ to its peer's
-valid observed address, so the handshake succeeds only when it originates from that side.
-[`punchy.respond`](/docs/config/punchy/#punchyrespond) exists for exactly this — it has the difficult side retry the
-handshake in the reverse direction, whichever host wanted the tunnel.
+\* The mixed pairing is direct but direction-sensitive. The host behind the hard NAT can still dial _out_ to its peer's
+valid observed address, so the handshake succeeds only when it starts from that side — and only if the easy side's
+[inbound filtering](#easy-nat-endpoint-independent) accepts it. [`punchy.respond`](/docs/config/punchy/#punchyrespond)
+exists for exactly this: it has the difficult side retry the handshake in the reverse direction, no matter which host
+wanted the tunnel.
 
 ## When punching fails anyway
 
 In rough order of preference:
 
-1. **Enable punchy.** [`punchy.punch`](/docs/config/punchy/#punchypunch) keeps mappings alive;
+1. **Enable punchy.** [`punchy.punch`](/docs/config/punchy/#punchypunch) keeps mappings alive.
    [`punchy.respond`](/docs/config/punchy/#punchyrespond) retries the handshake in the reverse direction, which rescues
    some one-sided NAT situations.
-2. **Give the host a dialable address.** A port forward plus
-   [`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs) sidesteps observation entirely —
-   peers dial a known-good address, no punching required. See [How Hosts Find Each Other](/docs/guides/host-discovery/).
-3. **Use relays.** [Relays](/docs/config/relay/) are the designed fallback when no direct path exists: a mutually
-   reachable host forwards traffic between the two peers, and the tunnel stays end-to-end encrypted — the relay can see
-   routing metadata but not contents.
+2. **Give the host a public address.** A port forward plus
+   [`lighthouse.advertise_addrs`](/docs/config/lighthouse/#lighthouseadvertise_addrs) skips observation entirely. Peers
+   dial a known-good address, so no punching is needed. Pin [`listen.port`](/docs/config/listen/) so the forward has a
+   stable target, and see [How Hosts Find Each Other](/docs/guides/host-discovery/) for how the advertised address
+   spreads.
+3. **Use relays.** [Relays](/docs/config/relay/) are the designed fallback when no direct path exists. A host that both
+   peers can reach forwards traffic between them. The tunnel stays end-to-end encrypted — the relay can see routing
+   metadata, but not contents. The cost is performance, not security: traffic takes an extra hop, so expect added
+   latency, and throughput is limited by the relay's own connection.
 
 ## Telling direct from relayed
 
-A relayed tunnel works, so it's easy to not notice one. In the logs (see
-[Viewing Nebula logs](/docs/guides/viewing-nebula-logs/)), the `from` field on `Handshake message received` lines shows
-a plain address for a direct tunnel and is suffixed for a relayed one:
+A relayed tunnel still works, so it's easy to miss. Check the logs (see
+[Viewing Nebula logs](/docs/guides/viewing-nebula-logs/)). On `Handshake message received` lines, the `from` field shows
+a plain underlay address for a direct tunnel and carries a `(relayed)` suffix for a relayed one. The `relay` field names
+the relay by its Nebula address:
 
 ```
 msg="Handshake message received" from="203.0.113.9:4242 (relayed)" ...
 msg="Send handshake via relay" relay=192.168.100.1 ...
 ```
 
-A host that consistently handshakes `(relayed)` with peers it should reach directly is the signature of one of the NAT
-behaviors above. The [debug SSH commands](/docs/guides/debug-ssh-commands/) can also print the current remotes and
-relays for each tunnel.
+A host that always handshakes `(relayed)` with peers it should reach directly is the signature of one of the
+[hard NAT behaviors](#hard-nat-symmetric-nat-cgnat) above. The [debug SSH commands](/docs/guides/debug-ssh-commands/)
+can also print the current remotes and relays for each tunnel.
 
 ## Managed Nebula
 
@@ -132,8 +163,8 @@ relays for each tunnel.
 
 In [Managed Nebula](https://admin.defined.net), generated configs enable
 [`punchy.punch`](/docs/config/punchy/#punchypunch) and [`punchy.respond`](/docs/config/punchy/#punchyrespond) on every
-host (lighthouses excepted — they shouldn't be behind a NAT), lighthouses require a static address, and any host can be
-made a relay from the admin panel — see
+host. (Lighthouses are the exception — they shouldn't be behind a NAT.) Lighthouses require a static address, and any
+host can be made a relay from the admin panel — see
 [Using dedicated relays](https://docs.defined.net/guides/using-dedicated-relays/).
 
 :::
@@ -144,3 +175,5 @@ made a relay from the admin panel — see
 - [`relay` reference](/docs/config/relay/)
 - [`listen` reference](/docs/config/listen/)
 - [How Hosts Find Each Other](/docs/guides/host-discovery/)
+- [Connectivity and NAT traversal](https://docs.defined.net/architecture/#connectivity-and-nat-traversal) in the Managed
+  Nebula architecture overview

--- a/docs/guides/rotating-certificate-authority/index.mdx
+++ b/docs/guides/rotating-certificate-authority/index.mdx
@@ -5,7 +5,7 @@ summary:
   This guide will teach you how to migrate from an expiring certificate authority by creating a new certificate
   authority, updating your device's Nebula config to trust the new authority, signing new host certificates, and
   removing the old certificate authority from the trust bundle.
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # How to rotate to a new certificate authority

--- a/docs/guides/running-nebula-as-non-root/index.mdx
+++ b/docs/guides/running-nebula-as-non-root/index.mdx
@@ -5,7 +5,7 @@ description:
 summary:
   On Linux, Nebula does not need to run as root. This guide shows how to run it as a dedicated unprivileged user by
   granting the CAP_NET_ADMIN capability, either through systemd or with file capabilities on the binary.
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Running Nebula as a non-root user

--- a/docs/guides/sign-certificates-with-public-keys/index.mdx
+++ b/docs/guides/sign-certificates-with-public-keys/index.mdx
@@ -4,7 +4,7 @@ description: How to sign Nebula certificates without copying private keys across
 summary:
   After reading this guide you will be able to create public/private keypairs on devices you wish to add to the Nebula
   network and generate certificates for them using only the public key.
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # How to use public keys to create signed certificates

--- a/docs/guides/unsafe_routes/index.mdx
+++ b/docs/guides/unsafe_routes/index.mdx
@@ -6,7 +6,7 @@ description:
 summary:
   This guide explains how to configure Nebula to route traffic destined for a specific subnet through a specific overlay
   network host, which is useful for accessing hosts that cannot be modified to run Nebula.
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Extending network access beyond overlay hosts

--- a/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
+++ b/docs/guides/upgrade-to-cert-v2-and-ipv6/index.mdx
@@ -5,7 +5,7 @@ description:
   addresses.
 summary:
   This guide describes how to upgrade an existing nebula network to the v2 certificate format and enable IPv6 addresses.
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # Upgrading a Nebula network to IPv6 overlay addresses

--- a/docs/guides/using-lighthouse-dns/index.mdx
+++ b/docs/guides/using-lighthouse-dns/index.mdx
@@ -2,7 +2,7 @@
 title: Using Lighthouse DNS with Nebula
 description:
   Configure Nebula's experimental built-in DNS server on Lighthouse hosts to resolve overlay network hostnames.
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Using Lighthouse DNS with Nebula

--- a/docs/guides/viewing-nebula-logs/index.mdx
+++ b/docs/guides/viewing-nebula-logs/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Viewing Nebula logs
 description: How to view Nebula logs on Linux, macOS, Windows, iOS, and Android for troubleshooting and monitoring.
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 import ThemedImage from '@theme/ThemedImage';


### PR DESCRIPTION
New guide answering the questions a network engineer asks when Nebula hosts sit behind their firewall — the checklist that existing pages ([`punchy`](https://nebula.defined.net/docs/config/punchy/), [`relay`](https://nebula.defined.net/docs/config/relay/), [host discovery](https://nebula.defined.net/docs/guides/host-discovery/), one paragraph in the DN architecture page) only cover piecemeal:

- How hole punching works, at the level of NAT mappings
- What the network must allow: outbound UDP, endpoint-independent mapping (RFC 4787), timeouts vs `punchy` keepalives, inbound only for lighthouses/relays
- NAT behaviors that break punching: symmetric / per-session allocation (with a verified Palo Alto DIPP → [Persistent NAT for DIPP](https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-new-features/networking-features/persistent-nat-for-dipp) note), CGNAT, short UDP timeouts
- The mitigation ladder: `punchy` → port forward + `advertise_addrs` → relays
- How to spot a relayed tunnel: the `(relayed)` suffix on the `from` field in handshake logs

Placement: slots in at position 3, right after How Hosts Find Each Other (its natural sequel); later guides renumbered. Log strings verified against nebula source (`hostmap.go` `ViaSender.String`), Managed Nebula punchy defaults verified against generated configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yeo64wtbbMPxtUtmsWRAc
